### PR TITLE
OAuth2 implementation for CalDAV syncing

### DIFF
--- a/contrib/caldav/README
+++ b/contrib/caldav/README
@@ -18,7 +18,9 @@ Usage
 
 calcurse-caldav requires an up-to-date version of calcurse and a configuration
 file located at ~/.calcurse/caldav/config. An example configuration file can be
-found under contrib/caldav/config.sample in the calcurse source tree.
+found under contrib/caldav/config.sample in the calcurse source tree. You will
+also need to install *httplib2* for Python 3 using *pip* (e.g. `pip3 install
+--user httplib2`) or your distribution's package manager.
 
 If you run calcurse-caldav for the first time, you need to provide the --init
 argument. You can choose between the following initialization modes:

--- a/contrib/caldav/README.md
+++ b/contrib/caldav/README.md
@@ -22,7 +22,7 @@ found under contrib/caldav/config.sample in the calcurse source tree. You will
 also need to install *httplib2* for Python 3 using *pip* (e.g. `pip3 install
 --user httplib2`) or your distribution's package manager.
 
-If you run calcurse-caldav for the first time, you need to provide the --init
+If you run calcurse-caldav for the first time, you need to provide the `--init`
 argument. You can choose between the following initialization modes:
 
     --init=keep-remote Remove all local calcurse items and import remote objects
@@ -51,7 +51,7 @@ How It Works
 ------------
 
 calcurse-caldav creates a so-called synchronization database at
-~/.calcurse/caldav/sync.db that always keeps a snapshot of the last time the
+`~/.calcurse/caldav/sync.db` that always keeps a snapshot of the last time the
 script was executed. When running the script, it compares the objects on the
 server and the local objects with that snapshot to identify items that were
 added or deleted. It then

--- a/contrib/caldav/README.md
+++ b/contrib/caldav/README.md
@@ -65,3 +65,93 @@ added or deleted. It then
 Note: Since calcurse does not use unique identifiers for items, it cannot keep
 track of moved/edited items. Thus, modifying an item is equivalent to deleting
 the old item and creating a new one.
+
+OAuth2 Authentication
+---------------------
+
+calcurse-caldav also has support for services requiring OAuth2 authentication
+such as Google Calendar. Note that you can only have a single calendar synced
+at any given time, regardless of authentication method. To enable OAuth2 you
+will need to:
+
+* Change *AuthMethod* from "*basic*" to "*oauth2*" in your config file
+* Fill in the appropriate settings in your config file: "*ClientID*",
+ "*ClientSecret*", "*Scope*", and "*RedirectURI*". These can be obtained from
+ the API provider. (See below for Google Calendar)
+* Install *oauth2client* for Python 3 using *pip* (e.g. `pip3 install --user
+oauth2client`) or your distribution's package manager
+
+Synchronization With Google Calendar
+-------------------------------------
+
+You will need to use your Google account to create a Google API project and
+enable both the CalDAV API and the Google Calendar API. We will be doing this to
+receive a Client ID and Client Secret. The hostname, path, scope and redirect
+URI are listed below.
+
+First, you will need to go to the [Google Developers Console](https://console.developers.google.com/project) and click *Create
+Project*. After doing that, you can go to the [API Library](https://console.developers.google.com/project/_/apiui/apis/library) and
+search for the CalDAV API and enable it for your project. You will then need to
+do the same for the Google Calendar API.
+
+Next, go to the [Credentials page](https://console.developers.google.com/project/_/apiui/credential)
+, click on *Create credentials*, and choose *OAuth client ID*. If it asks you
+to "set a product name on the consent screen", click on *Configure consent
+screen* to do so. Any product name will do. Upon saving and returning to the
+"Create client ID" screen, choose *Other* as the Application type and click
+*Create*. You now have your Client ID and Client Secret to put into your
+calcurse-caldav config file!
+
+The following options should also be changed in your config file:
+
+```
+Hostname = apidata.googleusercontent.com
+Path = /caldav/v2/*your_calendar_id_here*/events/
+Scope = https://www.googleapis.com/auth/calendar
+```
+
+Your Calendar ID for "*Path*" should be your email for the default calendar.
+If you have multiple calendars, you can get the Calendar ID by going under
+Calendar Details at [calendar.google.com](https://calendar.google.com).
+The default Redirect URI in the config file is http://127.0.0.1; this should
+work fine, but can be changed to http://localhost, a local web server, or
+another device if you encounter errors related to it.
+
+A complete config file for example@gmail.com would have the following options:
+
+```
+[General]
+
+...
+
+Hostname = apidata.googleusercontent.com
+Path = /caldav/v2/example@gmail.com/events/
+AuthMethod = oauth2
+
+...
+
+[OAuth2]
+ClientID = 22802342jlkjlksjdlfkjq1htpvbcn.apps.googleusercontent.com
+ClientSecret = XPYGqHFsfF343GwJeOGiUi
+Scope = https://www.googleapis.com/auth/calendar
+RedirectURI = http://127.0.0.1
+```
+
+[The full guide from Google can be found here.](https://developers.google.com/google-apps/calendar/caldav/v2/guide)
+
+Upon your first run with the `--init` flag, you will be asked to go to a URL to
+log in and authorize synchronization with your Google account. You can access
+this URL on any other device if you cannot open a browser locally (e.g., on
+a headless server). Once you authorize synchronization, you will be redirected
+to your Redirect URI with a code attached to the end, e.g.,
+`http://127.0.0.1/?code=4/Ok6mBNW2nppfIwyL-Q1ZPVkEk3zZdZN3mHcY#`. You will need
+to copy the code after `http://12.0.0.1?code=`. In this case, it would be
+`4/Ok6mBNW2nppfIwyL-Q1ZPVkEk3zZdZN3mHcY#`.
+
+Finally pass this authorization code to calcurse-caldav with the `--authcode`
+flag and initialize the synchronization database like so (note that the quotes
+around the authorization code might be necessary or not, depending on your shell):
+
+```
+calcurse-caldav --init keep-remote --authcode '4/Ok6mBNW2nppfIwyL-Q1ZPVkEk3zZdZN3mHcY#'
+```

--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -10,6 +10,7 @@ import ssl
 import subprocess
 import sys
 import textwrap
+import urllib.parse
 import xml.etree.ElementTree as etree
 
 
@@ -242,7 +243,7 @@ def push_object(conn, objhash):
             etag = next(iter(etagdict.values()))
     etag = etag.strip('"')
 
-    return (href, etag)
+    return (urllib.parse.quote(href), etag)
 
 
 def push_objects(objhashes, conn, syncdb, etagdict):

--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -183,7 +183,9 @@ def remote_wipe(conn):
     if dry_run:
         return
 
-    remote_query(conn, "DELETE", path, {}, None)
+    remote_items = get_etags(conn)
+    for href in remote_items:
+        remove_remote_object(conn, remote_items[href], href)
 
 
 def get_syncdb(fn):

--- a/contrib/caldav/config.sample
+++ b/contrib/caldav/config.sample
@@ -12,6 +12,9 @@ Hostname = some.hostname.com
 # Path to the CalDAV calendar on the host specified above.
 Path = /path/to/calendar/on/the/server/
 
+# Type of authentication to use. Must be "basic" or "oauth2"
+#AuthMethod = basic
+
 # Enable this if you want to skip SSL certificate checks.
 InsecureSSL = No
 
@@ -33,3 +36,16 @@ Verbose = Yes
 # Optionally specify additional HTTP headers here.
 #[CustomHeaders]
 #User-Agent = Mac_OS_X/10.9.2 (13C64) CalendarAgent/176
+
+# Use the following to synchronize with an OAuth2-based service
+# such as Google Calendar.
+#[OAuth2]
+#ClientID = your_client_id
+#ClientSecret = your_client_secret
+
+# Scope of access for API calls. Synchronization requires read/write.
+#Scope = https://example.com/resource/scope
+
+# Change the redirect URI if you receive errors, but ensure that it is identical
+# to the redirect URI you specified in the API settings.
+#RedirectURI = http://127.0.0.1


### PR DESCRIPTION
I used the original CalDAV script to make another one for syncing with OAuth2 servers, such as Google's CalDAV server. 

In the new script, I changed a few functions such as `remote_query` and `remote_wipe` as well as the authorization functions to work with the new libraries (`httpslib2` and `oauth2client`). Installation of these libraries may be required. I also appended OAuth2 options onto the sample config file.

I tested all use cases (remove local, remove remote, push, pull, etc.) , each type of syncdb init (keep-remote, keep-local, and two-way), and both debug and verbose messages with Google CalDAV. But if anything looks off or I need to document something better, I'd be glad to go back and fix it!

