### PR TITLE
Add options to read password from environment

### DIFF
--- a/contrib/caldav/README.md
+++ b/contrib/caldav/README.md
@@ -32,6 +32,14 @@ argument. You can choose between the following initialization modes:
 For subsequent calcurse-caldav invocations, you don't need to specify any
 additional parameters.
 
+You can specify a username and password for basic authentication in the
+config file. Alternatively, the password can be passed securely from another
+program (such as *pass*) via the `CALCURSE_CALDAV_PASSWORD` environment variable like
+so:
+```
+CALCURSE_CALDAV_PASSWORD=$(pass show calcurse) calcurse-caldav
+```
+
 Hooks
 -----
 

--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -508,6 +508,9 @@ authcode = args.authcode
 verbose = args.verbose
 debug = args.debug
 
+# Read environment variables
+password = os.getenv('CALCURSE_CALDAV_PASSWORD')
+
 # Read configuration.
 config = configparser.RawConfigParser()
 if verbose:
@@ -563,10 +566,8 @@ if config.has_option('Auth', 'UserName'):
 else:
     username = None
 
-if config.has_option('Auth', 'Password'):
+if config.has_option('Auth', 'Password') and not password:
     password = config.get('Auth', 'Password')
-else:
-    password = None
 
 if config.has_section('CustomHeaders'):
     custom_headers = dict(config.items('CustomHeaders'))


### PR DESCRIPTION
An extension of #49. As @dasJ mentioned, it is more secure to pass it through an environment variable as it wouldn't show up in something like top or ps. 

I also documented the external password support. 