### PR TITLE
Fix end-of-string calculation

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -731,7 +731,7 @@ void keys_fill_missing(void)
 							  "\"%s\" was already assigned!"),
 							 keydef[i].label,
 							 key_ch);
-					p += strlen(key_ch) + 1;
+					p += strlen(key_ch);
 				} else {
 					break;
 				}


### PR DESCRIPTION
In keys_fill_missing() a pointer is walked through a string of space-separated
character names, but misses the string-terminating null character.

The error is not reliably reproducible because it depends on the memory layout.
I experienced it when the keys file were accidentically empty.