### PR TITLE
Scrollbar and right window border (corrected)

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -170,6 +170,9 @@
 /* Size of the hash table the note garbage collector uses. */
 #define NOTE_GC_HSIZE 1024
 
+/* Mnemonics */
+#define NOHILT		0 	/* 'No highlight' argument */
+
 #define ERROR_MSG(...) do {                                                   \
   char msg[BUFSIZ];                                                           \
   int len;                                                                    \
@@ -908,7 +911,7 @@ void listbox_resize(struct listbox *, int, int, int, int);
 void listbox_set_cb_data(struct listbox *, void *);
 void listbox_load_items(struct listbox *, int);
 void listbox_draw_deco(struct listbox *, int);
-void listbox_display(struct listbox *);
+void listbox_display(struct listbox *, int);
 int listbox_get_sel(struct listbox *);
 void listbox_set_sel(struct listbox *, unsigned);
 void listbox_sel_move(struct listbox *, int);
@@ -1144,7 +1147,7 @@ long date_sec_change(long, int, int);
 long update_time_in_date(long, unsigned, unsigned);
 time_t get_sec_date(struct date);
 long min2sec(unsigned);
-void draw_scrollbar(struct scrollwin *);
+void draw_scrollbar(struct scrollwin *, int);
 void item_in_popup(const char *, const char *, const char *, const char *);
 time_t get_today(void);
 long now(void);
@@ -1236,7 +1239,7 @@ void wins_scrollwin_resize(struct scrollwin *, int, int, int, int);
 void wins_scrollwin_set_linecount(struct scrollwin *, unsigned);
 void wins_scrollwin_delete(struct scrollwin *);
 void wins_scrollwin_draw_deco(struct scrollwin *, int);
-void wins_scrollwin_display(struct scrollwin *);
+void wins_scrollwin_display(struct scrollwin *, int);
 void wins_scrollwin_up(struct scrollwin *, int);
 void wins_scrollwin_down(struct scrollwin *, int);
 int wins_scrollwin_is_visible(struct scrollwin *, unsigned);

--- a/src/custom.c
+++ b/src/custom.c
@@ -813,7 +813,7 @@ void custom_general_config(void)
 		     general_option_height, print_general_option);
 	listbox_load_items(&lb, NB_OPTIONS);
 	listbox_draw_deco(&lb, 0);
-	listbox_display(&lb);
+	listbox_display(&lb, NOHILT);
 	wins_set_bindings(bindings, ARRAY_SIZE(bindings));
 	wins_status_bar();
 	wnoutrefresh(win[STA].p);
@@ -847,7 +847,7 @@ void custom_general_config(void)
 			}
 		}
 
-		listbox_display(&lb);
+		listbox_display(&lb, NOHILT);
 		wins_status_bar();
 		wnoutrefresh(win[STA].p);
 		wmove(win[STA].p, 0, 0);
@@ -952,7 +952,7 @@ void custom_keys_config(void)
 	custom_keys_config_bar();
 	selrow = selelm = 0;
 	nbrowelm = print_keys_bindings(kwin.inner, selrow, selelm, LINESPERKEY);
-	wins_scrollwin_display(&kwin);
+	wins_scrollwin_display(&kwin, NOHILT);
 	firstrow = 0;
 	lastrow = firstrow + nbdisplayed - 1;
 	for (;;) {
@@ -1021,7 +1021,7 @@ void custom_keys_config(void)
 								selrow,
 								selelm,
 								LINESPERKEY);
-					wins_scrollwin_display(&kwin);
+					wins_scrollwin_display(&kwin, NOHILT);
 					wins_redrawwin(grabwin);
 					continue;
 				}
@@ -1074,7 +1074,7 @@ void custom_keys_config(void)
 		nbrowelm =
 		    print_keys_bindings(kwin.inner, selrow, selelm,
 					LINESPERKEY);
-		wins_scrollwin_display(&kwin);
+		wins_scrollwin_display(&kwin, NOHILT);
 	}
 }
 

--- a/src/listbox.c
+++ b/src/listbox.c
@@ -134,7 +134,7 @@ void listbox_draw_deco(struct listbox *lb, int hilt)
 	wins_scrollwin_draw_deco(&(lb->sw), hilt);
 }
 
-void listbox_display(struct listbox *lb)
+void listbox_display(struct listbox *lb, int hilt)
 {
 	int i;
 
@@ -145,7 +145,7 @@ void listbox_display(struct listbox *lb)
 		lb->fn_draw(i, lb->sw.inner, lb->ch[i], is_sel, lb->cb_data);
 	}
 
-	wins_scrollwin_display(&(lb->sw));
+	wins_scrollwin_display(&(lb->sw), hilt);
 }
 
 int listbox_get_sel(struct listbox *lb)

--- a/src/notify.c
+++ b/src/notify.c
@@ -786,7 +786,7 @@ void notify_config_bar(void)
 		     config_option_height, print_config_option);
 	listbox_load_items(&lb, 8);
 	listbox_draw_deco(&lb, 0);
-	listbox_display(&lb);
+	listbox_display(&lb, NOHILT);
 	wins_set_bindings(bindings, ARRAY_SIZE(bindings));
 	wins_status_bar();
 	wnoutrefresh(win[STA].p);
@@ -824,7 +824,7 @@ void notify_config_bar(void)
 			clearok(curscr, TRUE);
 		}
 
-		listbox_display(&lb);
+		listbox_display(&lb, NOHILT);
 		wins_status_bar();
 		wnoutrefresh(win[STA].p);
 		wmove(win[STA].p, 0, 0);

--- a/src/ui-calendar.c
+++ b/src/ui-calendar.c
@@ -580,7 +580,7 @@ void ui_calendar_update_panel(void)
 	ui_calendar_store_current_date(&current_day);
 	sunday_first = !ui_calendar_week_begins_on_monday();
 	draw_calendar[ui_calendar_view] (&sw_cal, &current_day, sunday_first);
-	wins_scrollwin_display(&sw_cal);
+	wins_scrollwin_display(&sw_cal, NOHILT);
 }
 
 /* Set the selected day in calendar to current day. */

--- a/src/ui-day.c
+++ b/src/ui-day.c
@@ -967,9 +967,9 @@ int ui_day_height(int n, void *cb_data)
 }
 
 /* Updates the Appointment panel */
-void ui_day_update_panel(int which_pan)
+void ui_day_update_panel(int hilt)
 {
-	listbox_display(&lb_apt);
+	listbox_display(&lb_apt, hilt);
 }
 
 void ui_day_popup_item(void)

--- a/src/ui-todo.c
+++ b/src/ui-todo.c
@@ -268,7 +268,7 @@ void ui_todo_sel_move(int delta)
 }
 
 /* Updates the TODO panel. */
-void ui_todo_update_panel(int which_pan)
+void ui_todo_update_panel(int hilt)
 {
 	/*
 	 * This is used and modified by ui_todo_draw() to avoid quadratic
@@ -277,7 +277,7 @@ void ui_todo_update_panel(int which_pan)
 	llist_item_t *p = LLIST_FIRST(&todolist);
 
 	listbox_set_cb_data(&lb_todo, &p);
-	listbox_display(&lb_todo);
+	listbox_display(&lb_todo, hilt);
 }
 
 /* Change an item priority by pressing '+' or '-' inside TODO panel. */

--- a/src/utils.c
+++ b/src/utils.c
@@ -574,8 +574,7 @@ long min2sec(unsigned minutes)
  * Display a scroll bar when there are so many items that they
  * can not be displayed inside the corresponding panel.
  */
-void
-draw_scrollbar(struct scrollwin *sw)
+void draw_scrollbar(struct scrollwin *sw, int hilt)
 {
 	int y = (conf.compact_panels ? 1 : 3);
 	int h = sw->h - (conf.compact_panels ? 2 : 4);
@@ -584,20 +583,14 @@ draw_scrollbar(struct scrollwin *sw)
 	int sbar_y = y + sw->line_off * (h - sbar_h) / (sw->line_num - h);
 	int sbar_x = sw->w - 1;
 
-	/* which scrollwin am I? */
-	enum win swid = -1;
-	if (strcmp(sw->label, _("TODO")) == 0)
-		swid = TOD;
-	else if (strcmp(sw->label, _("Appointments")) == 0)
-		swid = APP;
-	/*
-	 * Redraw the vertical right border.
-	 * For APP and TOD this is done as part of the move up/down.
-	 */
-	if (swid == -1)
-		mvwvline(sw->win, y, sbar_x, ACS_VLINE, h);
+	/* Redraw part of the border. */
+	if (hilt)
+		custom_apply_attr(sw->win, ATTR_HIGHEST);
+	mvwvline(sw->win, y, sbar_x, ACS_VLINE, h);
+	if (hilt)
+		custom_remove_attr(sw->win, ATTR_HIGHEST);
 
-	int hilt = swid == wins_slctd();
+	/* Draw the scrollbar. */
 	if (hilt)
 		custom_apply_attr(sw->win, ATTR_HIGHEST);
 	wattron(sw->win, A_REVERSE);

--- a/src/wins.c
+++ b/src/wins.c
@@ -355,7 +355,7 @@ void wins_scrollwin_draw_deco(struct scrollwin *sw, int hilt)
 }
 
 /* Display a scrolling window. */
-void wins_scrollwin_display(struct scrollwin *sw)
+void wins_scrollwin_display(struct scrollwin *sw, int hilt)
 {
 	int inner_y = sw->y + (conf.compact_panels ? 1 : 3);
 	int inner_x = sw->x + 1;
@@ -363,7 +363,7 @@ void wins_scrollwin_display(struct scrollwin *sw)
 	int inner_w = sw->w - 2;
 
 	if (sw->line_num > inner_h)
-		draw_scrollbar(sw);
+		draw_scrollbar(sw, hilt);
 	wmove(win[STA].p, 0, 0);
 	wnoutrefresh(sw->win);
 	/*
@@ -547,9 +547,9 @@ void wins_update_border(int flags)
 void wins_update_panels(int flags)
 {
 	if (flags & FLAG_APP)
-		ui_day_update_panel(slctd_win);
+		ui_day_update_panel(slctd_win == APP);
 	if (flags & FLAG_TOD)
-		ui_todo_update_panel(slctd_win);
+		ui_todo_update_panel(slctd_win == TOD);
 	if (flags & FLAG_CAL)
 		ui_calendar_update_panel();
 }


### PR DESCRIPTION
When a scrollbar is on display in APP or TOD windows, the right
vertical border (outside the scrollbar) is not highlighted
when the window is selected.

The scrollbar is always highlighted:
- when APP or TOD is deselected
- in configuration windows where borders otherwise are not

The patch moves the scrollbar parameters (except highlight)
from arguments of draw_scrollbar() to the function itself.
The highlight argument was 1; instead it is set higher in
the call hierarchy (wins_update_panels()) and passed on down.