### PR TITLE
Add option to specify the configuration file used

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -83,7 +83,7 @@ enum {
 static void usage(void)
 {
 	printf("%s\n", _("usage: calcurse [--daemon|-F|-G|-g|-i<file>|-Q|--status|-x[<format>]]\n"
-			 "                [-c<file>] [-D<path>] [-h] [-q] [--read-only] [-v]\n"
+			 "                [-c<file>] [-C<file] [-D<path>] [-h] [-q] [--read-only] [-v]\n"
 			 "                [--filter-*] [--format-*]"));
 }
 
@@ -120,6 +120,7 @@ static void help_arg(void)
 	putchar('\n');
 	printf("%s\n", _("Miscellaneous:"));
 	printf("%s\n", _("  -c, --calendar <file>   Specify the calendar data file to use"));
+	printf("%s\n", _("  -C, --conf <file>       Specify the configuration file to use"));
 	printf("%s\n", _("  --daemon                Run notification daemon in the background"));
 	printf("%s\n", _("  -D, --directory <path>  Specify the data directory to use"));
 	printf("%s\n", _("  -g, --gc                Run the garbage collector and exit"));
@@ -404,17 +405,19 @@ int parse_args(int argc, char **argv)
 	int xfmt = IO_EXPORT_ICAL;
 	int dump_imported = 0, export_uid = 0;
 	/* Data file locations */
-	const char *cfile = NULL, *datadir = NULL, *ifile = NULL;
+	const char *cfile = NULL, *datadir = NULL, *ifile = NULL,
+	      *conffile = NULL;
 
 	int non_interactive = 1;
 	int ch;
 	regex_t reg;
 
-	static const char *optstr = "FgGhvnNax::t::d:c:r::s::S:D:i:l:qQ";
+	static const char *optstr = "FgGhvnNax::t::C:d:c:r::s::S:D:i:l:qQ";
 
 	struct option longopts[] = {
 		{"appointment", no_argument, NULL, 'a'},
 		{"calendar", required_argument, NULL, 'c'},
+		{"conf", required_argument, NULL, 'C'},
 		{"day", required_argument, NULL, 'd'},
 		{"directory", required_argument, NULL, 'D'},
 		{"filter", no_argument, NULL, 'F'},
@@ -474,6 +477,9 @@ int parse_args(int argc, char **argv)
 			break;
 		case 'c':
 			cfile = optarg;
+			break;
+		case 'C':
+			conffile = optarg;
 			break;
 		case 'd':
 			if (is_all_digit(optarg)) {
@@ -716,7 +722,7 @@ int parse_args(int argc, char **argv)
 	else if (to >= 0 && range >= 0)
 		EXIT_IF(to >= 0, _("cannot specify a range and an end date"));
 
-	io_init(cfile, datadir);
+	io_init(cfile, datadir, conffile);
 	io_check_dir(path_dir);
 	io_check_dir(path_notes);
 

--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -837,7 +837,7 @@ void ical_export_data(FILE *, int);
 
 /* io.c */
 unsigned io_fprintln(const char *, const char *, ...);
-void io_init(const char *, const char *);
+void io_init(const char *, const char *, const char *);
 void io_extract_data(char *, const char *, int);
 void io_dump_apts(const char *, const char *, const char *, const char *);
 unsigned io_save_apts(const char *);

--- a/src/io.c
+++ b/src/io.c
@@ -226,16 +226,21 @@ unsigned io_fprintln(const char *fname, const char *fmt, ...)
  * one (~/.calcurse/apts) is taken. If the one given does not exist, it
  * is created.
  * The datadir argument can be use to specify an alternative data root dir.
+ * The conffile argument can be use to specify an alternative configuration file.
  */
-void io_init(const char *cfile, const char *datadir)
+void io_init(const char *cfile, const char *datadir, const char *conffile)
 {
 	const char *home;
 
 	if (datadir != NULL) {
 		home = datadir;
 		snprintf(path_dir, BUFSIZ, "%s", home);
+		if (conffile != NULL){
+			snprintf(path_conf, BUFSIZ, "%s", conffile);
+		} else {
+			snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, home);
+		}
 		snprintf(path_todo, BUFSIZ, "%s/" TODO_PATH_NAME, home);
-		snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, home);
 		snprintf(path_notes, BUFSIZ, "%s/" NOTES_DIR_NAME, home);
 		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH_NAME, home);
 		snprintf(path_cpid, BUFSIZ, "%s/" CPID_PATH_NAME, home);
@@ -248,9 +253,13 @@ void io_init(const char *cfile, const char *datadir)
 		if (home == NULL) {
 			home = ".";
 		}
+		if (conffile != NULL){
+			snprintf(path_conf, BUFSIZ, "%s", conffile);
+		} else {
+			snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, home);
+		}
 		snprintf(path_dir, BUFSIZ, "%s/" DIR_NAME, home);
 		snprintf(path_todo, BUFSIZ, "%s/" TODO_PATH, home);
-		snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH, home);
 		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH, home);
 		snprintf(path_cpid, BUFSIZ, "%s/" CPID_PATH, home);
 		snprintf(path_dpid, BUFSIZ, "%s/" DPID_PATH, home);


### PR DESCRIPTION
The configuration file (~/.calcurse/conf by default) can now be specified with
-C or --conf.

Workaround for GitHub issue #86.


Let me know if more changes are required.