### PR TITLE
Check for empty string in config_parse_int()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -151,12 +151,15 @@ static int config_parse_unsigned(unsigned *dest, const char *val)
 
 static int config_parse_int(int *dest, const char *val)
 {
-	if ((*val == '+' || *val == '-' || isdigit(*val))
-	    && is_all_digit(val + 1))
+	char *cp = (char *)val;
+
+	if (*val == '+' || *val == '-')
+		cp++;
+	/* Test for empty string before checking for digits only. */
+	if (*cp && is_all_digit(cp))
 		*dest = atoi(val);
 	else
 		return 0;
-
 	return 1;
 }
 


### PR DESCRIPTION
We had an email discussion about the semantics of is_all_digit() and what it should return on an empty string.

I ended accepting your view, but the correction in config_parse_int() was never implemented.