### PR TITLE
Solve deadlock in notification bar

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -1208,6 +1208,7 @@ extern struct pad apad;
 extern struct nbar nbar;
 extern struct dmon_conf dmon;
 void vars_init(void);
+extern pthread_t notify_t_main, io_t_psave, ui_calendar_t_date;
 
 /* wins.c */
 extern struct window win[NBWINS];

--- a/src/io.c
+++ b/src/io.c
@@ -1501,8 +1501,6 @@ void io_log_free(struct io_file *log)
 	mem_free(log);
 }
 
-static pthread_t io_t_psave;
-
 /* Thread used to periodically save data. */
 static void *io_psave_thread(void *arg)
 {
@@ -1524,7 +1522,8 @@ void io_start_psave_thread(void)
 /* Stop periodic data saves. */
 void io_stop_psave_thread(void)
 {
-	if (!io_t_psave)
+	/* Is the thread running? */
+	if (pthread_equal(io_t_psave, pthread_self()))
 		return;
 
 	/* Lock the mutex to avoid cancelling the thread during saving. */
@@ -1532,6 +1531,7 @@ void io_stop_psave_thread(void)
 	pthread_cancel(io_t_psave);
 	pthread_join(io_t_psave, NULL);
 	io_mutex_unlock();
+	io_t_psave = pthread_self();
 }
 
 /*

--- a/src/ui-calendar.c
+++ b/src/ui-calendar.c
@@ -47,7 +47,6 @@
 static struct date today, slctd_day;
 static unsigned ui_calendar_view, week_begins_on_monday;
 static pthread_mutex_t date_thread_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_t ui_calendar_t_date;
 
 static void draw_monthly_view(struct scrollwin *, struct date *, unsigned);
 static void draw_weekly_view(struct scrollwin *, struct date *, unsigned);
@@ -120,10 +119,13 @@ void ui_calendar_start_date_thread(void)
 /* Stop the calendar date thread. */
 void ui_calendar_stop_date_thread(void)
 {
-	if (ui_calendar_t_date) {
-		pthread_cancel(ui_calendar_t_date);
-		pthread_join(ui_calendar_t_date, NULL);
-	}
+	/* Is the thread running? */
+	if (pthread_equal(ui_calendar_t_date, pthread_self()))
+		return;
+
+	pthread_cancel(ui_calendar_t_date);
+	pthread_join(ui_calendar_t_date, NULL);
+	ui_calendar_t_date = pthread_self();
 }
 
 /* Set static variable today to current date */

--- a/src/vars.c
+++ b/src/vars.c
@@ -102,6 +102,9 @@ struct nbar nbar;
 /* Variable to store daemon configuration. */
 struct dmon_conf dmon;
 
+/* Thread id variables for threads that never exit. */
+pthread_t notify_t_main, io_t_psave, ui_calendar_t_date;
+
 /*
  * Variables init
  */
@@ -166,4 +169,7 @@ void vars_init(void)
 
 	/* Start at the current date */
 	ui_calendar_init_slctd_day();
+
+	/* Threads not yet running. */
+	notify_t_main = io_t_psave = ui_calendar_t_date = pthread_self();
 }


### PR DESCRIPTION
The pull request is concerned with the way threads are stopped in calcurse. It as an alternative to commit https://github.com/lfos/calcurse/commit/30f411257ad3bc233184c08b846a2980a9c5d1f0, but also takes care of the periodic save thread and the calendar date thread.

There is a detailed explanation of the problem in the commit message.