### PR TITLE
Use a path instead of a file for -C option

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -83,7 +83,7 @@ enum {
 static void usage(void)
 {
 	printf("%s\n", _("usage: calcurse [--daemon|-F|-G|-g|-i<file>|-Q|--status|-x[<format>]]\n"
-			 "                [-c<file>] [-C<file] [-D<path>] [-h] [-q] [--read-only] [-v]\n"
+			 "                [-c<file>] [-C<path>] [-D<path>] [-h] [-q] [--read-only] [-v]\n"
 			 "                [--filter-*] [--format-*]"));
 }
 
@@ -120,7 +120,7 @@ static void help_arg(void)
 	putchar('\n');
 	printf("%s\n", _("Miscellaneous:"));
 	printf("%s\n", _("  -c, --calendar <file>   Specify the calendar data file to use"));
-	printf("%s\n", _("  -C, --conf <file>       Specify the configuration file to use"));
+	printf("%s\n", _("  -C, --conf <path>       Specify the configuration path to use"));
 	printf("%s\n", _("  --daemon                Run notification daemon in the background"));
 	printf("%s\n", _("  -D, --directory <path>  Specify the data directory to use"));
 	printf("%s\n", _("  -g, --gc                Run the garbage collector and exit"));
@@ -406,7 +406,7 @@ int parse_args(int argc, char **argv)
 	int dump_imported = 0, export_uid = 0;
 	/* Data file locations */
 	const char *datadir = NULL;
-	const char *cfile = NULL, *ifile = NULL, *conffile = NULL;
+	const char *cfile = NULL, *ifile = NULL, *confdir = NULL;
 
 	int non_interactive = 1;
 	int ch;
@@ -479,7 +479,7 @@ int parse_args(int argc, char **argv)
 			cfile = optarg;
 			break;
 		case 'C':
-			conffile = optarg;
+			confdir = optarg;
 			break;
 		case 'd':
 			if (is_all_digit(optarg) ||
@@ -726,7 +726,7 @@ int parse_args(int argc, char **argv)
 	else if (range < 0)
 		from = date_sec_change(to, 0, range);
 
-	io_init(cfile, datadir, conffile);
+	io_init(cfile, datadir, confdir);
 	io_check_dir(path_dir);
 	io_check_dir(path_notes);
 

--- a/src/io.c
+++ b/src/io.c
@@ -225,45 +225,48 @@ unsigned io_fprintln(const char *fname, const char *fmt, ...)
  * which contains the calendar file. If none is given, then the default
  * one (~/.calcurse/apts) is taken. If the one given does not exist, it
  * is created.
- * The datadir argument can be use to specify an alternative data root dir.
- * The conffile argument can be use to specify an alternative configuration file.
+ * The datadir argument can be used to specify an alternative data root dir.
+ * The confdir argument can be used to specify an alternative configuration dir.
  */
-void io_init(const char *cfile, const char *datadir, const char *conffile)
+void io_init(const char *cfile, const char *datadir, const char *confdir)
 {
 	const char *home;
 
 	if (datadir != NULL) {
 		home = datadir;
+
 		snprintf(path_dir, BUFSIZ, "%s", home);
-		if (conffile)
-			snprintf(path_conf, BUFSIZ, "%s", conffile);
-		else
-			snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, home);
+		if (!confdir)
+			confdir = path_dir;
+
+		snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, confdir);
+		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH_NAME, confdir);
+		snprintf(path_hooks, BUFSIZ, "%s/" HOOKS_DIR_NAME, confdir);
+
 		snprintf(path_todo, BUFSIZ, "%s/" TODO_PATH_NAME, home);
-		snprintf(path_notes, BUFSIZ, "%s/" NOTES_DIR_NAME, home);
-		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH_NAME, home);
 		snprintf(path_cpid, BUFSIZ, "%s/" CPID_PATH_NAME, home);
 		snprintf(path_dpid, BUFSIZ, "%s/" DPID_PATH_NAME, home);
-		snprintf(path_dmon_log, BUFSIZ, "%s/" DLOG_PATH_NAME,
-			 home);
-		snprintf(path_hooks, BUFSIZ, "%s/" HOOKS_DIR_NAME, home);
+		snprintf(path_notes, BUFSIZ, "%s/" NOTES_DIR_NAME, home);
+		snprintf(path_dmon_log, BUFSIZ, "%s/" DLOG_PATH_NAME, home);
 	} else {
 		home = getenv("HOME");
 		if (home == NULL) {
 			home = ".";
 		}
-		if (conffile)
-			snprintf(path_conf, BUFSIZ, "%s", conffile);
-		else
-			snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH, home);
+
 		snprintf(path_dir, BUFSIZ, "%s/" DIR_NAME, home);
+		if (!confdir)
+			confdir = path_dir;
+
+		snprintf(path_conf, BUFSIZ, "%s/" CONF_PATH_NAME, confdir);
+		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH_NAME, confdir);
+		snprintf(path_hooks, BUFSIZ, "%s/" HOOKS_DIR_NAME, confdir);
+
 		snprintf(path_todo, BUFSIZ, "%s/" TODO_PATH, home);
-		snprintf(path_keys, BUFSIZ, "%s/" KEYS_PATH, home);
 		snprintf(path_cpid, BUFSIZ, "%s/" CPID_PATH, home);
 		snprintf(path_dpid, BUFSIZ, "%s/" DPID_PATH, home);
-		snprintf(path_dmon_log, BUFSIZ, "%s/" DLOG_PATH, home);
 		snprintf(path_notes, BUFSIZ, "%s/" NOTES_DIR, home);
-		snprintf(path_hooks, BUFSIZ, "%s/" HOOKS_DIR, home);
+		snprintf(path_dmon_log, BUFSIZ, "%s/" DLOG_PATH, home);
 	}
 
 	if (cfile == NULL) {


### PR DESCRIPTION
Allows to specify a configuration directory containing:
* conf
* keys
* hooks

When used in combination with -D $ddir, $ddir contains all the other
files not mentioned above.

I implemented it as a required argument, instead of what was suggested of having a default `config/` folder used when the argument is not given. I think this option will only be used in aliases anyway, meaning that it's ok for people to write some full path once.

Related: #111.