### PR TITLE
Note export functionality (DESCRIPTION) for ical + newline fix for unix systems

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -955,6 +955,7 @@ void edit_note(char **, const char *);
 void view_note(const char *, const char *);
 void erase_note(char **);
 void note_read(char *, FILE *);
+char* read_note_content(char *);
 void note_gc(void);
 
 /* notify.c */

--- a/src/ical.c
+++ b/src/ical.c
@@ -254,8 +254,12 @@ static void ical_export_recur_apoints(FILE * stream, int export_uid)
 			fputs("EXDATE:", stream);
 			LLIST_FOREACH(&rapt->exc, j) {
 				struct excp *exc = LLIST_GET_DATA(j);
-				date_sec2date_fmt(exc->st, ICALDATEFMT,
+				date_sec2date_fmt(exc->st, ICALDATETIMEFMT,
 						  ical_date);
+				for (int i=0;i<5;i++) {
+					ical_date[9+i] = ical_datetime[9+i];
+				}
+				
 				fprintf(stream, "%s", ical_date);
 				fputc(LLIST_NEXT(j) ? ',' : '\n', stream);
 			}

--- a/src/ical.c
+++ b/src/ical.c
@@ -182,6 +182,12 @@ static void ical_export_recur_events(FILE * stream, int export_uid)
 
 		fprintf(stream, "SUMMARY:%s\n", rev->mesg);
 
+		if (rev->note) {
+			char* note = read_note_content(rev->note);
+			fprintf(stream,"DESCRIPTION:%s",note);
+			free(note);
+		}
+
 		if (export_uid) {
 			char *hash = recur_event_hash(rev);
 			fprintf(stream, "UID:%s\n", hash);
@@ -204,6 +210,12 @@ static void ical_export_events(FILE * stream, int export_uid)
 		fputs("BEGIN:VEVENT\n", stream);
 		fprintf(stream, "DTSTART;VALUE=DATE:%s\n", ical_date);
 		fprintf(stream, "SUMMARY:%s\n", ev->mesg);
+
+		if (ev->note) {
+			char* note = read_note_content(ev->note);
+			fprintf(stream,"DESCRIPTION:%s",note);
+			free(note);
+		}
 
 		if (export_uid) {
 			char *hash = event_hash(ev);

--- a/src/io.c
+++ b/src/io.c
@@ -181,7 +181,7 @@ static FILE *get_export_stream(enum export_type type)
 			mem_free(stream_name);
 			return NULL;
 		}
-		stream = fopen(stream_name, "w");
+		stream = fopen(stream_name, "w+");
 		if (stream == NULL) {
 			status_mesg(wrong_name, press_enter);
 			keys_wait_for_any_key(win[KEY].p);

--- a/src/note.c
+++ b/src/note.c
@@ -155,6 +155,35 @@ void note_read(char *buffer, FILE * fp)
 	buffer[MAX_NOTESIZ] = '\0';
 }
 
+char* read_note_content(char *file_name) 
+{
+	FILE *data_file;
+	char* full_path;
+	long length;
+	char* buffer;
+
+	asprintf(&full_path, "%s%s", path_notes, file_name);
+
+	data_file = fopen(full_path, "rb");
+	EXIT_IF(data_file == NULL, _("failed to open note file"));
+	
+	fseek(data_file, 0, SEEK_END);
+	length = ftell(data_file);	
+	fseek(data_file, 0, SEEK_SET);
+
+	buffer = malloc(length+1);	
+	
+	if (buffer) {
+		if (!fread(buffer, 1, length, data_file)) {
+			free(buffer);
+			return NULL;
+		}
+	}
+	buffer[length] = '\0';
+	fclose(data_file);
+	return buffer;
+}
+
 static void
 note_gc_extract_key(struct note_gc_hash *data, const char **key, int *len)
 {


### PR DESCRIPTION
I added the function `ical_format_newlines` to convert LF line endings to CR+LF, which is the standard for the ical format. This is called after all vevent components are written to the file. I changed the file stream `stream`'s method from `w` to `w+` to facilitate this.

I also added functionality to export the note of appointments and events, and todos using the DESCRIPTION parameter of the ical standard, as it is currently unused and is roughly analogous to the note parameter of calcurse's. To accomplish this, I added the function `read_note_content` to `note.c`, as well as its prototype to `calcurse.h,` which extracts the note content using the filename stored in the respective structure.