### PR TITLE
Export note to .ical files

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -955,6 +955,7 @@ void edit_note(char **, const char *);
 void view_note(const char *, const char *);
 void erase_note(char **);
 void note_read(char *, FILE *);
+char* read_note_content(char *);
 void note_gc(void);
 
 /* notify.c */

--- a/src/ical.c
+++ b/src/ical.c
@@ -97,56 +97,6 @@ static void ical_export_footer(FILE * stream)
 	fputs("END:VCALENDAR\n", stream);
 }
 
-static void ical_format_newlines(FILE * stream) 
-{
-	char *buffer;
-	long length,newlines = 0;
-	int c,i = 0;
-
-	fseek(stream,0,SEEK_SET);
-
-	while (c != EOF) {
-		c = getc(stream);
-		if (c == '\r') {
-			c = getc(stream);
-		}
-		else if (c == '\n') {
-			newlines++;
-		}
-	}
-	
-	fseek(stream,0,SEEK_END);
-	length = ftell(stream) + newlines;
-
-	buffer = malloc(length+1);
-
-	fseek(stream,0,SEEK_SET);
-
-	c = 0;
-	while (c != EOF) {
-		c = getc(stream);
-		if (c == '\r') {
-			buffer[i] = c;
-			c = getc(stream);
-		}
-		else if (c == '\n') {
-			buffer[i] = '\r';
-			i++;
-		}
-		buffer[i] = c;
-		i++;
-	}
-
-	buffer[length] = '\0';
-
-	fseek(stream,0,SEEK_SET);
-
-	fwrite(buffer,1,length,stream);
-
-	free(buffer);
-	fseek(stream,0,SEEK_SET);
-}
-
 /* Export recurrent events. */
 static void ical_export_recur_events(FILE * stream, int export_uid)
 {
@@ -254,12 +204,8 @@ static void ical_export_recur_apoints(FILE * stream, int export_uid)
 			fputs("EXDATE:", stream);
 			LLIST_FOREACH(&rapt->exc, j) {
 				struct excp *exc = LLIST_GET_DATA(j);
-				date_sec2date_fmt(exc->st, ICALDATETIMEFMT,
+				date_sec2date_fmt(exc->st, ICALDATEFMT,
 						  ical_date);
-				for (int i=0;i<5;i++) {
-					ical_date[9+i] = ical_datetime[9+i];
-				}
-				
 				fprintf(stream, "%s", ical_date);
 				fputc(LLIST_NEXT(j) ? ',' : '\n', stream);
 			}
@@ -1248,5 +1194,4 @@ void ical_export_data(FILE * stream, int export_uid)
 	ical_export_apoints(stream, export_uid);
 	ical_export_todo(stream, export_uid);
 	ical_export_footer(stream);
-	ical_format_newlines(stream);
 }

--- a/src/ical.c
+++ b/src/ical.c
@@ -227,7 +227,6 @@ static void ical_export_recur_apoints(FILE * stream, int export_uid)
 			fprintf(stream,"DESCRIPTION:%s",note);
 			free(note);
 		}
-		//fprintf(stream,"STATUS:CONFIRMED\n");
 
 		fprintf(stream, "SUMMARY:%s\n", rapt->mesg);
 		if (rapt->state & APOINT_NOTIFY)
@@ -237,7 +236,6 @@ static void ical_export_recur_apoints(FILE * stream, int export_uid)
 			char *hash = recur_apoint_hash(rapt);
 			fprintf(stream, "UID:%s\n", hash);
 			mem_free(hash);
-
 		}
 
 		fputs("END:VEVENT\n", stream);

--- a/src/note.c
+++ b/src/note.c
@@ -155,6 +155,35 @@ void note_read(char *buffer, FILE * fp)
 	buffer[MAX_NOTESIZ] = '\0';
 }
 
+char* read_note_content(char *file_name) 
+{
+	FILE *data_file;
+	char* full_path;
+	long length;
+	char* buffer;
+
+	asprintf(&full_path, "%s%s", path_notes, file_name);
+
+	data_file = fopen(full_path, "rb");
+	EXIT_IF(data_file == NULL, _("failed to open note file"));
+	
+	fseek(data_file, 0, SEEK_END);
+	length = ftell(data_file);	
+	fseek(data_file, 0, SEEK_SET);
+
+	buffer = malloc(length+1);	
+	
+	if (buffer) {
+		if (!fread(buffer, 1, length, data_file)) {
+			free(buffer);
+			return NULL;
+		}
+	}
+	buffer[length] = '\0';
+	fclose(data_file);
+	return buffer;
+}
+
 static void
 note_gc_extract_key(struct note_gc_hash *data, const char **key, int *len)
 {


### PR DESCRIPTION
I've modified the export feature for the ical format by allowing notes in calcurse to be included in the file under the property 'DESCRIPTION' in accordance with the icalendar standard. This is logical because the 'DESCRIPTION' feature is currently unused and is roughly analogous to the note feature in calcurse.

To accomplish this, I added the function `read_note_content` to `note.c`, as well as its prototype to `calcurse.h`, which extracts the note content using the filename stored in the respective struct. This function is called in `ical.c`  from functions `ical_export_apoints`, `ical_export_recur_apoints`, `ical_export_events`, `ical_export_recur_events`, and `ical_export_todo`, after checking if the provided struct's `note` member is not null. It then outputs the note like normal.