### PR TITLE
DST updates

### DIFF
--- a/src/apoint.c
+++ b/src/apoint.c
@@ -326,7 +326,10 @@ void apoint_switch_notify(struct apoint *apt)
 
 void apoint_paste_item(struct apoint *apt, long date)
 {
-	apt->start = date + get_item_time(apt->start);
+	struct tm t;
+
+	localtime_r((time_t *)&apt->start, &t);
+	apt->start = update_time_in_date(date, t.tm_hour, t.tm_min);
 
 	LLIST_TS_LOCK(&alist_p);
 	LLIST_TS_ADD_SORTED(&alist_p, apt, apoint_cmp);

--- a/src/apoint.c
+++ b/src/apoint.c
@@ -137,7 +137,7 @@ void apoint_sec2str(struct apoint *o, long day, char *start, char *end)
 		snprintf(start, HRMIN_SIZE, "%02u:%02u", lt.tm_hour,
 			 lt.tm_min);
 	}
-	if (o->start + o->dur > day + DAYINSEC) {
+	if (o->start + o->dur > day + DAYLEN(day)) {
 		strncpy(end, "..:..", 6);
 	} else {
 		t = o->start + o->dur;

--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -144,7 +144,13 @@
 #define WEEKINMIN       (WEEKINHOURS * HOURINMIN)
 #define WEEKINSEC       (WEEKINMIN * MININSEC)
 #define DAYINMIN        (DAYINHOURS * HOURINMIN)
+/*
+ * Note the difference between the number of seconds in a day and daylength
+ * in seconds. The two may differ when DST is in effect (daylength is either
+ * 23, 24 or 25 hours. The argument to DAYLEN is of type time_t.
+ */
 #define DAYINSEC        (DAYINMIN * MININSEC)
+#define DAYLEN(date)	(date_sec_change((date), 0, 1) - (date))
 #define HOURINSEC       (HOURINMIN * MININSEC)
 
 #define MAXDAYSPERMONTH 31

--- a/src/day.c
+++ b/src/day.c
@@ -294,7 +294,7 @@ static int day_store_apoints(long date)
 
 		p.apt = apt;
 
-		if (apt->start >= date + DAYINSEC)
+		if (apt->start >= date + DAYLEN(date))
 			break;
 
 		day_add_item(APPT, apt->start, p);

--- a/src/recur.c
+++ b/src/recur.c
@@ -995,18 +995,23 @@ void recur_event_paste_item(struct recur_event *rev, long date)
 
 void recur_apoint_paste_item(struct recur_apoint *rapt, long date)
 {
-	long time_shift;
+	long ostart = rapt->start;
+	int days;
 	llist_item_t *i;
+	struct tm t;
 
-	time_shift = (date + get_item_time(rapt->start)) - rapt->start;
-	rapt->start += time_shift;
+	localtime_r((time_t *)&rapt->start, &t);
+	rapt->start = update_time_in_date(date, t.tm_hour, t.tm_min);
+
+	/* The number of days shifted. */
+	days = (rapt->start - ostart) / DAYINSEC;
 
 	if (rapt->rpt->until != 0)
-		rapt->rpt->until += time_shift;
+		rapt->rpt->until = date_sec_change(rapt->rpt->until, 0, days);
 
 	LLIST_FOREACH(&rapt->exc, i) {
 		struct excp *exc = LLIST_GET_DATA(i);
-		exc->st += time_shift;
+		exc->st = date_sec_change(exc->st, 0, days);
 	}
 
 	LLIST_TS_LOCK(&recur_alist_p);

--- a/src/ui-calendar.c
+++ b/src/ui-calendar.c
@@ -97,7 +97,7 @@ static void *ui_calendar_date_thread(void *arg)
 	time_t actual, tomorrow;
 
 	for (;;) {
-		tomorrow = (time_t) (get_today() + DAYINSEC);
+		tomorrow = date2sec(today, 24, 0);
 
 		while ((actual = time(NULL)) < tomorrow)
 			sleep(tomorrow - actual);

--- a/src/ui-day.c
+++ b/src/ui-day.c
@@ -332,7 +332,7 @@ static void update_rept(struct rpt **rpt, const long start)
 				keys_wgetch(win[KEY].p);
 				continue;
 			}
-			newuntil = start + days * DAYINSEC;
+			newuntil = date_sec_change(start, 0, days);
 		} else {
 			int year, month, day;
 			if (!parse_date(timstr, conf.input_datefmt, &year,
@@ -836,7 +836,7 @@ void ui_day_item_repeat(void)
 				keys_wgetch(win[KEY].p);
 				continue;
 			}
-			until = p->start + days * DAYINSEC;
+			until = date_sec_change(p->start, 0, days);
 		} else {
 			int year, month, day;
 			if (!parse_date(user_input, conf.input_datefmt,

--- a/src/utils.c
+++ b/src/utils.c
@@ -530,24 +530,20 @@ long date_sec_change(long date, int delta_month, int delta_day)
 	return t;
 }
 
-/*
- * Return a long containing the date which is updated taking into account
- * the new time and date entered by the user.
- */
-long update_time_in_date(long date, unsigned hr, unsigned mn)
+/* A time in seconds is updated with new hour and minutes and returned. */
+time_t update_time_in_date(time_t date, unsigned hr, unsigned mn)
 {
 	struct tm lt;
-	time_t t, new_date;
 
-	t = date;
-	localtime_r(&t, &lt);
+	localtime_r(&date, &lt);
 	lt.tm_hour = hr;
 	lt.tm_min = mn;
 	lt.tm_sec = 0;
-	new_date = mktime(&lt);
-	EXIT_IF(new_date == -1, _("error in mktime"));
+	lt.tm_isdst = -1;
+	date = mktime(&lt);
+	EXIT_IF(date == -1, _("error in mktime"));
 
-	return new_date;
+	return date;
 }
 
 /*


### PR DESCRIPTION
The recent end of Daylight Saving Time on 28 October caused some deficiensies to be exposed.

One type had to do with the length of a day, another with increments in dates (adding a time interval to a point in time). A straightforward bug has also been fixed. Each type is in a seperate commit.

In most of the cases I have reproduced the error before the correction and verified its absence afterwards.