### PR TITLE
closing the export stream after being done with export

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1186,6 +1186,7 @@ void io_export_data(enum export_type type, int export_uid)
 		pcal_export_data(stream);
 
 	if (show_dialogs() && ui_mode == UI_CURSES) {
+        fclose(stream);
 		status_mesg(success, enter);
 		keys_wait_for_any_key(win[KEY].p);
 	}


### PR DESCRIPTION
solves lfos/calcurse#178

close the stream when done writing to it in `io_export_data` this results in the export file being updated immediately.