### PR TITLE
Fix empty dynamic string

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1186,6 +1186,7 @@ void io_export_data(enum export_type type, int export_uid)
 		pcal_export_data(stream);
 
 	if (show_dialogs() && ui_mode == UI_CURSES) {
+		fclose(stream);
 		status_mesg(success, enter);
 		keys_wait_for_any_key(win[KEY].p);
 	}

--- a/src/strings.c
+++ b/src/strings.c
@@ -45,6 +45,7 @@ void string_init(struct string *sb)
 	sb->buf = mem_malloc(STRING_INITIAL_BUFSIZE);
 	sb->bufsize = STRING_INITIAL_BUFSIZE;
 	sb->len = 0;
+	*sb->buf = '\0';
 }
 
 void string_reset(struct string *sb)


### PR DESCRIPTION
No known bug fixed by this, but during work on a new feature I ended up editing non-initialized memory.