### PR TITLE
Exception days

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -1008,6 +1008,8 @@ void pcal_export_data(FILE *);
 /* recur.c */
 extern llist_ts_t recur_alist_p;
 extern llist_t recur_elist;
+void recur_update_exc(llist_t *, char *);
+char *recur_exc2str(llist_t *);
 struct recur_event *recur_event_dup(struct recur_event *);
 struct recur_apoint *recur_apoint_dup(struct recur_apoint *);
 void recur_event_free_bkp(void);

--- a/src/io.c
+++ b/src/io.c
@@ -1186,6 +1186,7 @@ void io_export_data(enum export_type type, int export_uid)
 		pcal_export_data(stream);
 
 	if (show_dialogs() && ui_mode == UI_CURSES) {
+		fclose(stream);
 		status_mesg(success, enter);
 		keys_wait_for_any_key(win[KEY].p);
 	}

--- a/src/ui-day.c
+++ b/src/ui-day.c
@@ -367,6 +367,22 @@ cleanup:
 	mem_free(outstr);
 }
 
+/* Edit the list of exception days for a recurrent item. */
+static void update_exc(llist_t *exc)
+{
+	if (!exc->head)
+		return;
+	char *days;
+	enum getstr ret;
+
+	status_mesg(_("Exception days:"), "");
+	days = recur_exc2str(exc);
+	ret = updatestring(win[STA].p, &days, 0, 1);
+	if (ret == GETSTRING_VALID || ret == GETSTRING_RET)
+		recur_update_exc(exc, days);
+	mem_free(days);
+}
+
 /* Edit an already existing item. */
 void ui_day_item_edit(void)
 {
@@ -386,7 +402,7 @@ void ui_day_item_edit(void)
 		re = p->item.rev;
 		const char *choice_recur_evnt[2] = {
 			_("Description"),
-			_("Repetition"),
+			_("Repetition")
 		};
 		switch (status_ask_simplechoice
 			(_("Edit: "), choice_recur_evnt, 2)) {
@@ -396,6 +412,7 @@ void ui_day_item_edit(void)
 			break;
 		case 2:
 			update_rept(&re->rpt, re->day);
+			update_exc(&re->exc);
 			io_set_modified();
 			break;
 		default:
@@ -437,6 +454,7 @@ void ui_day_item_edit(void)
 		case 4:
 			need_check_notify = 1;
 			update_rept(&ra->rpt, ra->start);
+			update_exc(&ra->exc);
 			io_set_modified();
 			break;
 		case 5:


### PR DESCRIPTION
When you delete an occurrence of a recurrent event or appointment (as opposed to the entire repeated item), the day is added internally as an exception day.

This works well, but subsequently there is no way of removing the exception day (and get the occurrence back). In fact, given a repeating event/appointment, you cannot easily determine whether some occurrences have been deleted. You can, of course, view or even edit the data file `apts` (but that is cheating).

This commit makes it possible to edit the list of exception days by extending `(4) Repetition` of the edit item command. If exception days have been added, they are presented in the status line as a string of space-separated dates in your preferred input format. It may be viewed or edited as you like. The intention is that you only view or remove days. But there is nothing to stop you from adding new exception days, and they will do no harm. But there is no check that they are meaningful, only that they are valid dates.