### PR TITLE
[WIP] vdirsyncer support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS= foreign
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = po src test scripts contrib/caldav
+SUBDIRS = po src test scripts contrib/caldav contrib/vdirsyncer
 
 if ENABLE_DOCS
 SUBDIRS += doc

--- a/configure.ac
+++ b/configure.ac
@@ -142,8 +142,9 @@ AM_CONDITIONAL(CALCURSE_MEMORY_DEBUG, test x$memdebug = xyes)
 #-------------------------------------------------------------------------------
 #                                                               Create Makefiles
 #-------------------------------------------------------------------------------
-AC_OUTPUT(Makefile doc/Makefile src/Makefile test/Makefile scripts/Makefile \
-          po/Makefile.in po/Makefile contrib/caldav/Makefile)
+AC_OUTPUT(Makefile doc/Makefile src/Makefile test/Makefile \
+          scripts/Makefile po/Makefile.in po/Makefile \
+          contrib/caldav/Makefile contrib/vdirsyncer/Makefile)
 #-------------------------------------------------------------------------------
 #                                                                        Summary
 #-------------------------------------------------------------------------------

--- a/contrib/vdirsyncer/Makefile.am
+++ b/contrib/vdirsyncer/Makefile.am
@@ -1,0 +1,13 @@
+AUTOMAKE_OPTIONS = foreign
+
+dist_bin_SCRIPTS = \
+	calcurse-vdirsyncer
+
+EXTRA_DIST = \
+	calcurse-vdirsyncer.py
+
+CLEANFILES = \
+	calcurse-vdirsyncer
+
+calcurse-vdirsyncer: calcurse-vdirsyncer.py
+	cp "$(srcdir)/$<" "$@"

--- a/contrib/vdirsyncer/README.md
+++ b/contrib/vdirsyncer/README.md
@@ -1,0 +1,55 @@
+calcurse-vdirsyncer
+===============
+
+calcurse-vdirsyncer is a Python script that can be used to synchronize
+calcurse with a remote using [vdirsyncer](https://github.com/pimutils/vdirsyncer).
+Please note that the script is alpha software!  This means that:
+
+* We are eagerly looking for testers to run the script and give feedback! If
+  you find any bugs, please report them to the calcurse mailing lists or to the
+  GitHub bug tracker. If the script works fine for you, please report back as
+  well!
+
+* The script might still have bugs. MAKE BACKUPS, especially before running
+  calcurse-vdirsyncer for the first time!
+
+Usage
+-----
+
+calcurse-vdirsyncer requires an up-to-date version of calcurse and vdirsyncer.
+Vdirsyncer needs to be properly configured before running the script.
+See the [documentation](https://vdirsyncer.pimutils.org/en/stable/tutorial.html)
+for a full configuration tutorial.
+
+To run calcurse-vdirsyncer, call the script using
+
+```sh
+calcurse-vdirsyncer <vdir>
+```
+
+where `vdir` is the local storage directory specified in the vdirsyncer configuration file.
+
+You can optionally specify an alternative directory for local calcurse data using the
+`-D` flag if it differs from the default `~/.calcurse`.
+
+How It Works
+------------
+
+calcurse-vdirsyncer leverages vdirsyncer to synchronize calcurse data between
+different remotes. The script itself is a wrapper for calcurse import and export
+commands and vdirsyncer synchronization calls.
+
+When started, the script does the following
+
+- Export all calcurse objects to the vdir directory
+- Delete all local objects in the vdir directory not present in calcurse anymore
+- Synchronize the vdir directory using vdirsyncer
+- Import all new items in the vdir to calcurse
+- Delete all calcurse items removed from the remote
+
+Planned Updates
+---------------
+
+- Support for hook directories
+- Enable filtering of imported and exported items (events, todos)
+- Improve event parsing robustness

--- a/contrib/vdirsyncer/calcurse-vdirsyncer.py
+++ b/contrib/vdirsyncer/calcurse-vdirsyncer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import argparse
+import io
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+
+def msgfmt(msg, prefix=''):
+    """Print a formatted message"""
+    lines = []
+    for line in msg.splitlines():
+        lines += textwrap.wrap(line, 80 - len(prefix))
+    return '\n'.join([prefix + line for line in lines])
+
+
+def check_binary(binary):
+    """Check if a binary is available in $PATH"""
+    try:
+        subprocess.call([binary, '--version'], stdout=subprocess.DEVNULL)
+    except FileNotFoundError:
+        sys.exit(msgfmt("{0} is not available.".format(binary), "error: "))
+
+
+def check_directory(directory):
+    """Check if a directory exists"""
+    if not os.path.isdir(directory):
+        sys.exit(msgfmt("invalid directory: {0}".format(directory), "error: "))
+
+
+def write_file(file, contents):
+    """Write to file"""
+    if verbose:
+        msgfmt("Writing to file {0}".format(file))
+    with open(file, 'w') as f:
+        f.write(contents)
+
+
+def remove_file(file):
+    """Remove file"""
+    if verbose:
+        msgfmt("Deleting file {0}".format(file))
+    if os.path.isfile(file):
+        os.remove(file)
+
+
+def calcurse_export():
+    """Return raw calcurse data"""
+    command = calcurse + ['-xical', '--export-uid']
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    return [x for x in io.TextIOWrapper(proc.stdout, encoding="utf-8")]
+
+
+def calcurse_remove(uid):
+    """Remove calcurse event by uid"""
+    command = calcurse + ['-P', '--filter-hash=' + uid]
+    subprocess.call(command)
+
+
+def calcurse_import(file):
+    """Import ics file to calcurse"""
+    command = calcurse + ['-i', file]
+    subprocess.call(command)
+
+
+def calcurse_list():
+    """Return all calcurse item uids"""
+    command = calcurse + [
+        '-G',
+        '--format-apt=%(hash)\\n',
+        '--format-recur-apt=%(hash)\\n',
+        '--format-event=%(hash)\\n',
+        '--format-recur-event=%(hash)\\n',
+        '--format-todo=%(hash)\\n'
+    ]
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    return [x.strip() for x in io.TextIOWrapper(proc.stdout, encoding="utf-8")]
+
+
+def vdirsyncer_sync():
+    """Sync vdir using vdirsyncer"""
+    command = vdirsyncer + ['sync']
+    if force:
+        command += ['--force-delete']
+    subprocess.call(command)
+
+
+def parse_calcurse_data(raw):
+    """Parse raw calcurse data to a uid/ical dictionary"""
+
+    header = ''.join(raw[:3])
+    regex = '(BEGIN:(VEVENT|VTODO).*?END:(VEVENT|VTODO).)'
+    events = [x[0] for x in re.findall(regex, ''.join(raw), re.DOTALL)]
+
+    items = {}
+
+    for item in events:
+        uid = re.findall('UID:(.*?)\n', item)[0]
+        items[uid] = header + item + "END:VCALENDAR\n"
+
+    return items
+
+
+def calcurse_to_vdir():
+    """Export calcurse data to vdir"""
+    raw_events = calcurse_export()
+    events = parse_calcurse_data(raw_events)
+
+    files_old = [x for x in os.listdir(vdir)]
+    files_new = [uid + ".ics" for uid in events]
+
+    if not files_new == 0 and not force:
+        sys.exit(msgfmt("""no calcurse events were exported."""
+                        """ Use --force to synchronize anyways.""", 'error: '))
+
+    for file in files_old:
+        if file not in files_new:
+            remove_file(os.path.join(vdir, file))
+
+    for uid, event in events.items():
+        file = uid + ".ics"
+        if file not in files_old:
+            write_file(os.path.join(vdir, file), event)
+
+
+def vdir_to_calcurse():
+    """Import vdir data to calcurse"""
+    files_old = [x + '.ics' for x in calcurse_list()]
+    files_new = [x for x in os.listdir(vdir) if x.endswith('.ics')]
+
+    if not files_new == 0 and not force:
+        sys.exit(msgfmt("""the vdirsyncer directory is empty."""
+                        """ Use --force to synchronize anyways.""", 'error: '))
+
+    for file in files_new:
+        if file not in files_old:
+            calcurse_import(os.path.join(vdir, file))
+
+    for file in files_old:
+        if file not in files_new:
+            calcurse_remove(file[:-4])
+
+
+parser = argparse.ArgumentParser('calcurse-vdirsyncer')
+parser.add_argument('vdir',
+                    help='path to the vdir collection directory')
+parser.add_argument('-D', action='store', dest='datadir',
+                    default=None,
+                    help='path to the calcurse data directory')
+parser.add_argument('-v', '--verbose', action='store_true', dest='verbose',
+                    default=False,
+                    help='print status messages to stdout')
+parser.add_argument('-f', '--force', action='store_true', dest='force',
+                    default=False,
+                    help='for synchronization of empty collections')
+args = parser.parse_args()
+
+datadir = args.datadir
+force = args.force
+verbose = args.verbose
+vdir = args.vdir
+
+
+check_binary('calcurse')
+check_binary('vdirsyncer')
+
+calcurse = ['calcurse']
+vdirsyncer = ['vdirsyncer']
+
+check_directory(vdir)
+
+if datadir:
+    check_directory(datadir)
+    calcurse += ['-D', datadir]
+
+calcurse_to_vdir()
+vdirsyncer_sync()
+vdir_to_calcurse()


### PR DESCRIPTION
I wrote a < 100 loc script to sync calcurse with a remote using vdirsyncer (see #35) which works already really well since vdirsyncer does all the heavy lifting.

So far the script does the following:

1. Export all calcurse items and their uids using the same method as found in `calcurse-caldav`.
2. Save the exported items in the vdir directory and delete old events not present in calcurse anymore.
3. Sync to remote using vdirsyncer.
4. Remove elements delete from remote in calcurse, and import newly created ones

The script works without any issues when syncing with a Fastmail remote.

I am planning on improving the script in the next few days by:
- adding configuration flags (see #187) and removing hardcoded paths 
- Adding synchronization filters (e.g. evt, todo).

Once these improvements are made, this script would pretty much have the same features as `calcurse-caldav` since vdirsyncer takes care of the entire syncing process.

@lfos What other functionality or requirements would you consider necessary before potentially merging this PR?