### PR TITLE
Use ICALDATETIMEFMT for EXDATE

### DIFF
--- a/src/ical.c
+++ b/src/ical.c
@@ -123,7 +123,7 @@ static void ical_export_recur_events(FILE * stream, int export_uid)
 			fputs("EXDATE:", stream);
 			LLIST_FOREACH(&rev->exc, j) {
 				struct excp *exc = LLIST_GET_DATA(j);
-				date_sec2date_fmt(exc->st, ICALDATEFMT,
+				date_sec2date_fmt(exc->st, ICALDATETIMEFMT,
 						  ical_date);
 				fprintf(stream, "%s", ical_date);
 				fputc(LLIST_NEXT(j) ? ',' : '\n', stream);
@@ -202,7 +202,7 @@ static void ical_export_recur_apoints(FILE * stream, int export_uid)
 			fputs("EXDATE:", stream);
 			LLIST_FOREACH(&rapt->exc, j) {
 				struct excp *exc = LLIST_GET_DATA(j);
-				date_sec2date_fmt(exc->st, ICALDATEFMT,
+				date_sec2date_fmt(exc->st, ICALDATETIMEFMT,
 						  ical_date);
 				fprintf(stream, "%s", ical_date);
 				fputc(LLIST_NEXT(j) ? ',' : '\n', stream);


### PR DESCRIPTION
Hi, 

I imported some old entries from google calendar into calcurse 4.4.0 and got this error when syncing to a radicale server:
```
Pushing new object 213cdcf086e562a1e07608fc2ae6bc99468b813e to the server.
Running command: ['calcurse', '-xical', '--export-uid', '--filter-hash=213cdcf086e562a1e07608fc2ae6bc99468b813e']
> PUT [REMOVED].ics
> Headers: {'Content-Type': 'text/calendar; charset=utf-8'}
> BEGIN:VCALENDAR
> PRODID:-//calcurse//NONSGML v4.4.0//EN
> VERSION:2.0
> BEGIN:VEVENT
> DTSTART:20120422T080000
> DURATION:P0DT8H0M0S
> RRULE:FREQ=WEEKLY;INTERVAL=4;UNTIL=20120910
> EXDATE:20120812,20120909
> SUMMARY:Jobb 8-16
> UID:213cdcf086e562a1e07608fc2ae6bc99468b813e
> END:VEVENT
> END:VCALENDAR

< Status: 400 (Bad Request)
< Headers: {'date': 'Wed, 27 Mar 2019 17:25:52 GMT', 'server': 'WSGIServer/0.2 CPython/3.7.2', 'content-type': 'text/plain; charset=utf-8', 'content-length': '11', 'status': '400', '-content-encoding': 'gzip'}
< Bad Request
```

The radicale log shows a warning:
```
WARNING: Bad PUT request on "[REMOVED].ics": At line 15: '20120812' is not a valid DATE-TIME
```

I applied the patch in this PR and was able to send everything to the radicale server. 

It might make more sense to blaim radicale (or [vobject](https://github.com/eventable/vobject/blob/498555a553155ea9b26aace93332ae79365ecb31/vobject/icalendar.py#L1741)) for the error, but it should on the other hand not hurt to print a slightly more verbose date.