### PR TITLE
Fix edit of empty exception day list

### DIFF
--- a/src/ui-day.c
+++ b/src/ui-day.c
@@ -278,7 +278,7 @@ static int update_exc(llist_t *exc)
 	int updated = 0;
 
 	if (!exc->head)
-		return updated;
+		return !updated;
 	char *days;
 	enum getstr ret;
 


### PR DESCRIPTION
Correction to #221.

If the exception day list is left untouched, it has been correctly "updated". This is also true of the empty list.