### PR TITLE
Document the HTTPS option in the sample configuration file

### DIFF
--- a/contrib/caldav/config.sample
+++ b/contrib/caldav/config.sample
@@ -18,6 +18,10 @@ Path = /path/to/calendar/on/the/server/
 # Enable this if you want to skip SSL certificate checks.
 InsecureSSL = No
 
+# Disable this if you want to use HTTP instead of HTTPS.
+# Using plain HTTP is highly discouraged.
+HTTPS = Yes
+
 # This option allows you to filter the types of tasks synced. To this end, the
 # value of this option should be a comma-separated list of item types, where
 # each item type is either "event", "apt", "recur-event", "recur-apt", "todo",


### PR DESCRIPTION
#18 introduced the `HTTPS` option but it is missing from the sample configuration file, therefore it is not easily discoverable by new users (like me.)