### PR TITLE
Test for the directory structure

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,6 +4,12 @@ TESTS = \
 	true-001.sh \
 	run-test-001.sh \
 	run-test-002.sh \
+	io-001.sh \
+	io-002.sh \
+	io-003.sh \
+	io-004.sh \
+	io-005.sh \
+	io-006.sh \
 	todo-001.sh \
 	todo-002.sh \
 	todo-003.sh \

--- a/test/io-001.sh
+++ b/test/io-001.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+data=$(mktemp -d)
+
+"$CALCURSE" -a -D "$data"
+[ -f "$data/apts" ] && [ -f "$data/conf" ] && failed=0 || failed=1
+
+rm -rf "$data"
+exit "$failed"

--- a/test/io-002.sh
+++ b/test/io-002.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+data=$(mktemp -d)
+conf=$(mktemp -d)
+
+"$CALCURSE" -a -D "$data" -C "$conf"
+[ -f "$data/apts" ] && [ -f "$conf/conf" ] && failed=0 || failed=1
+
+rm -rf "$data" "$conf"
+exit "$failed"

--- a/test/io-003.sh
+++ b/test/io-003.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+home=$(mktemp -d)
+data="$home/.calcurse"
+
+mkdir "$data"
+HOME="$home" "$CALCURSE" -a
+[ -f "$data/apts" ] && [ -f "$data/conf" ] && failed=0 || failed=1
+
+rm -rf "$home"
+exit "$failed"

--- a/test/io-004.sh
+++ b/test/io-004.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+home=$(mktemp -d)
+data=$(mktemp -d)
+conf=$(mktemp -d)
+
+HOME="$home" XDG_DATA_HOME="$data" XDG_CONFIG_HOME="$conf" "$CALCURSE" -a
+[ -f "$data/calcurse/apts" ] && [ -f "$conf/calcurse/conf" ] && failed=0 || failed=1
+
+rm -rf "$home" "$data" "$conf"
+exit "$failed"

--- a/test/io-005.sh
+++ b/test/io-005.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+home=$(mktemp -d)
+
+CALCURSE=$(realpath "$CALCURSE")
+(unset -v XDG_DATA_HOME XDG_CONFIG_HOME; HOME="$home" "$CALCURSE" -a)
+[ -f "$home/.local/share/calcurse/apts" ] && [ -f "$home/.config/calcurse/conf" ] && failed=0 || failed=1
+
+rm -rf "$home"
+exit "$failed"

--- a/test/io-006.sh
+++ b/test/io-006.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. "${TEST_INIT:-./test-init.sh}"
+dir=$(mktemp -d)
+
+CALCURSE=$(realpath "$CALCURSE")
+cd "$dir"
+(unset -v HOME XDG_DATA_HOME XDG_CONFIG_HOME; "$CALCURSE" -a)
+[ -f "$dir/.calcurse/apts" ] && [ -f "$dir/.calcurse/conf" ] && failed=0 || failed=1
+
+rm -rf "$dir"
+exit "$failed"


### PR DESCRIPTION
Ensure that calcurse uses the right data and configuration directories depending on the conditions.

**Related:** #254 (issue: #252)