### PR TITLE
Display Notes in TODO View and Event/Appt. View

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -1019,6 +1019,7 @@ void edit_note(char **, const char *);
 void view_note(const char *, const char *);
 void erase_note(char **);
 void note_read(char *, FILE *);
+void note_read_contents(char *, size_t, FILE *);
 void note_gc(void);
 
 /* notify.c */

--- a/src/day.c
+++ b/src/day.c
@@ -582,8 +582,30 @@ void day_write_stdout(time_t date, const char *fmt_apt, const char *fmt_rapt,
 void day_popup_item(struct day_item *day)
 {
 	if (day->type == EVNT || day->type == RECUR_EVNT) {
-		item_in_popup(NULL, NULL, day_item_get_mesg(day),
-			      _("Event:"));
+		if (day_item_get_note(day)) {
+			size_t note_size = 3500;
+			char note[note_size];
+
+			char *notepath;
+			FILE *fp;
+			asprintf(&notepath, "%s%s", path_notes, day_item_get_note(day));
+
+			fp = fopen(notepath, "r");
+			mem_free(notepath);
+
+			note_read_contents(note, note_size, fp);
+			fclose(fp);
+
+			char *msg;
+
+			asprintf(&msg, "%s\n\nNOTES:\n%s", day_item_get_mesg(day), note);
+
+			item_in_popup(NULL, NULL, msg, _("Event:"));
+
+			mem_free(msg);
+		} else {
+			item_in_popup(NULL, NULL, day_item_get_mesg(day), _("Event:"));
+		}
 	} else if (day->type == APPT || day->type == RECUR_APPT) {
 		char a_st[100], a_end[100];
 
@@ -593,8 +615,30 @@ void day_popup_item(struct day_item *day)
 		apt_tmp.start = day->start;
 		apt_tmp.dur = day_item_get_duration(day);
 		apoint_sec2str(&apt_tmp, ui_day_sel_date(), a_st, a_end);
-		item_in_popup(a_st, a_end, day_item_get_mesg(day),
-			      _("Appointment:"));
+
+		if (day_item_get_note(day)) {
+			size_t note_size = 3500;
+			char note[note_size];
+
+			char *notepath;
+			FILE *fp;
+			asprintf(&notepath, "%s%s", path_notes, day_item_get_note(day));
+
+			fp = fopen(notepath, "r");
+			mem_free(notepath);
+
+			note_read_contents(note, note_size, fp);
+			fclose(fp);
+
+			char *msg;
+
+			asprintf(&msg, "%s\n\nNOTES:\n%s", day_item_get_mesg(day), note);
+			item_in_popup(a_st, a_end, msg, _("Appointment:"));
+
+			mem_free(msg);
+		} else {
+			item_in_popup(a_st, a_end, day_item_get_mesg(day), _("Appointment:"));
+		}
 	} else {
 		EXIT(_("unknown item type"));
 		/* NOTREACHED */

--- a/src/note.c
+++ b/src/note.c
@@ -155,6 +155,17 @@ void note_read(char *buffer, FILE * fp)
 	buffer[MAX_NOTESIZ] = '\0';
 }
 
+/* Read the contents of a note file */
+void note_read_contents(char *buffer, size_t buffer_len, FILE * fp)
+{
+	size_t read_count = fread(buffer, 1, buffer_len, fp);
+	if (read_count != buffer_len)
+		buffer[read_count] = '\0';
+	else
+		memcpy(&buffer[buffer_len - 4], "...\0", 4);
+}
+
+
 static void
 note_gc_extract_key(struct note_gc_hash *data, const char **key, int *len)
 {

--- a/src/ui-todo.c
+++ b/src/ui-todo.c
@@ -314,7 +314,30 @@ void ui_todo_popup_item(void)
 	if (!item)
 		return;
 
-	item_in_popup(NULL, NULL, item->mesg, _("TODO:"));
+	if (item->note) {
+		/* Assign a sane default note size that will cleanly
+		 * truncate long notes */
+		size_t note_size = 3500;
+		char note[note_size];
+
+		char *notepath;
+		FILE *fp;
+		asprintf(&notepath, "%s%s", path_notes, item->note);
+
+		fp = fopen(notepath, "r");
+		mem_free(notepath);
+		note_read_contents(note, note_size, fp);
+		fclose(fp);
+
+		char *msg;
+
+		asprintf(&msg, "%s\n\nNOTES:\n%s", item->mesg, note);
+
+		item_in_popup(NULL, NULL, msg, _("TODO:"));
+		mem_free(msg);
+	} else {
+		item_in_popup(NULL, NULL, item->mesg, _("TODO:"));
+	}
 }
 
 void ui_todo_flag(void)


### PR DESCRIPTION
This PR implements the feature requested in #289 and expands this functionality to events and appointments as well. When viewing TODO items or Events/Appts., if one exists, the associated note is displayed in the pop-up window and is truncated after reaching a specified character limit.

EDIT: I would like to be clear about the fact that I'm very inexperienced with C, and would appreciate any effort to review or further test the code from anyone willing to help :smile: