### PR TITLE
New feature: promote TODO items to APP items and toggleable APP events

### DIFF
--- a/src/calcurse.c
+++ b/src/calcurse.c
@@ -211,7 +211,13 @@ static inline void key_repeat_item(void)
 static inline void key_flag_item(void)
 {
 	if (wins_slctd() == APP && !event_dummy(ui_day_get_sel())) {
-		ui_day_flag();
+		struct day_item *item = ui_day_get_sel();
+		if(item->type == EVNT) {
+			ui_day_item_toggle_check();
+		} else {
+			ui_day_flag();
+		}
+		
 		do_storage(0);
 		wins_update(FLAG_APP);
 	} else if (wins_slctd() == TOD) {
@@ -265,6 +271,21 @@ static inline void key_view_note(void)
 	else if (wins_slctd() == TOD)
 		ui_todo_view_note();
 	wins_update(FLAG_ALL);
+}
+
+static inline void key_promote_note(void)
+{
+	if(wins_slctd() == TOD) {
+		ui_day_item_copy_note_to_event();
+		
+		struct todo *item = ui_todo_selitem();
+		todo_delete(item);
+		ui_todo_load_items();
+		io_set_modified();
+
+		do_storage(0);
+		wins_update(FLAG_CAL | FLAG_APP | FLAG_STA | FLAG_TOD);
+    }
 }
 
 static inline void key_generic_credits(void)
@@ -878,6 +899,7 @@ int main(int argc, char **argv)
 		HANDLE_KEY(KEY_LOWER_PRIORITY, key_lower_priority);
 		HANDLE_KEY(KEY_EDIT_NOTE, key_edit_note);
 		HANDLE_KEY(KEY_VIEW_NOTE, key_view_note);
+		HANDLE_KEY(KEY_PROMOTE_NOTE, key_promote_note);
 		HANDLE_KEY(KEY_GENERIC_CREDITS, key_generic_credits);
 		HANDLE_KEY(KEY_GENERIC_HELP, key_generic_help);
 		HANDLE_KEY(KEY_GENERIC_SAVE, key_generic_save);

--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -565,6 +565,7 @@ enum vkey {
 	KEY_REPEAT_ITEM,
 	KEY_EDIT_NOTE,
 	KEY_VIEW_NOTE,
+	KEY_PROMOTE_NOTE,
 	KEY_RAISE_PRIORITY,
 	KEY_LOWER_PRIORITY,
 
@@ -1150,6 +1151,8 @@ void todo_free_list(void);
 
 /* ui-day.c */
 void ui_day_item_add(void);
+void ui_day_item_copy_note_to_event(void);
+void ui_day_item_toggle_check(void);
 void ui_day_item_delete(unsigned);
 void ui_day_item_edit(void);
 void ui_day_item_pipe(void);
@@ -1177,6 +1180,7 @@ void ui_day_view_note(void);
 void ui_day_edit_note(void);
 
 /* ui-todo.c */
+struct todo *ui_todo_selitem(void);
 void ui_todo_add(void);
 void ui_todo_delete(void);
 void ui_todo_edit(void);

--- a/src/keys.c
+++ b/src/keys.c
@@ -153,8 +153,10 @@ static struct keydef_s keydef[NBVKEYS] = {
 	{ "repeat", "r", gettext_noop("Repeat") },
 	{ "edit-note", "n N", gettext_noop("EditNote") },
 	{ "view-note", ">", gettext_noop("ViewNote") },
+	{ "promote-note", "P", gettext_noop("PromoteNote") },
 	{ "raise-priority", "+", gettext_noop("Prio.+") },
 	{ "lower-priority", "-", gettext_noop("Prio.-") }
+
 };
 
 /*

--- a/src/ui-todo.c
+++ b/src/ui-todo.c
@@ -39,7 +39,7 @@
 
 static unsigned ui_todo_view = 0;
 
-static struct todo *ui_todo_selitem(void)
+struct todo *ui_todo_selitem(void)
 {
 	return todo_get_item(listbox_get_sel(&lb_todo),
 			     ui_todo_view == TODO_HIDE_COMPLETED_VIEW);


### PR DESCRIPTION
#328 
* Add new key handler 'P' that promotes TODO item into an event on a currently
  selected day. New event is allocated, TODO item mesg pointer is copied into
  it, then TODO item is disposed of (obviously, a bug)
  It also automatically turns it into a 'toggleable' event, which just means
  it prepends `[ ] ` to the message
* If "flag" (!) key is used on events in APP, it'll do one of the three things
  to the `mesg`:
    - if it starts with `[ ] `, replace it with `[x] `.
    - if it starts with `[x] `, replace it with `[ ] `.
    - if it starts with anything else, reallocate a new buffer of size
      strlen(mesg) + 4, copy original message into it and prepend a `[ ] `.