### PR TITLE
calcurse-caldav: allow non-ascii characters in username and password

### DIFF
--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -147,8 +147,8 @@ def calcurse_version():
 def get_auth_headers():
     if not username or not password:
         return {}
-    user_password = ('{}:{}'.format(username, password)).encode('ascii')
-    user_password = base64.b64encode(user_password).decode('ascii')
+    user_password = ('{}:{}'.format(username, password)).encode('utf-8')
+    user_password = base64.b64encode(user_password).decode('utf-8')
     headers = {'Authorization': 'Basic {}'.format(user_password)}
     return headers
 


### PR DESCRIPTION
Hi, 

I was trying to `calcurse-caldav` with a radicale server where password contained non-ascii characters, and got an error:
```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```
With this patch syncing works as expected.