### PR TITLE
When pushing local objects, always take href as it is returned by server

### DIFF
--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 import sys
 import textwrap
-import urllib.parse
 import xml.etree.ElementTree as etree
 
 import httplib2
@@ -425,13 +424,17 @@ def push_object(conn, objhash):
     headerdict = dict(headers)
     if 'etag' in headerdict:
         etag = headerdict['etag']
-    while not etag:
+
+    returned_href = None
+    while not etag or not returned_href:
         etagdict = get_etags(conn, [href])
         if etagdict:
-            etag = next(iter(etagdict.values()))
-    etag = etag.strip('"')
+            returned_href, returned_etag = next(iter(etagdict.items()))
+            if not etag:
+                etag = returned_etag
 
-    return (urllib.parse.quote(href), etag)
+    etag = etag.strip('"')
+    return (returned_href, etag)
 
 
 def push_objects(objhashes, conn, syncdb, etagdict):


### PR DESCRIPTION
Apparently, while some caldav servers will return href values as is in their response (as seen in https://github.com/lfos/calcurse/issues/337 and https://github.com/lfos/calcurse/issues/356), some might return them url-escaped (which if I am not mistaken was the reason for https://github.com/lfos/calcurse/commit/e943b0605ff7000280bcf190f35f9097a6ae5f67).

Assuming either behaviour when pushing local objects will lead to discrepancy with events dictionary retrieved from the server and thus bugs, hence we always want to use whatever form of href the server returns.