### PR TITLE
Fixed sidebar config sometime not increasing width

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -175,6 +175,8 @@ void vars_init(void)
 
 	ui_calendar_set_first_day_of_week(MONDAY);
 
+	wins_set_sbar_width(col * SBARMINWIDTH / 100);
+
 	/* Pad structure to scroll text inside the appointment panel */
 	apad.length = 1;
 	apad.first_onscreen = 0;

--- a/src/wins.c
+++ b/src/wins.c
@@ -229,7 +229,7 @@ void wins_sbar_winc(void)
 
 void wins_sbar_wdec(void)
 {
-	if (sbarwidth_perc > 0)
+	if (col * sbarwidth_perc / 100 > SBARMINWIDTH)
 		sbarwidth_perc--;
 }
 


### PR DESCRIPTION
The sidebar has a numerical mimumum width that is statically defined,
and users may set the width of the sidebar in config by incrementing the
percentage of the screen between this minimum and a maximum value of
50%. However, internally the mimimum percentage could be set as low as
zero, and while that did not decrease the sidebar size below the
numerical minimum width, did mean that between 0 and the mimimum width
increasing the percentage had no visual effect to indicate change. Now
the mimimum percent is not decremented below the mimimum width.

Signed-off-by: Morgan Seltzer <MorganSeltzer000@gmail.com>