### PR TITLE
fix typo in caldav post-sync hook git commit message

### DIFF
--- a/contrib/caldav/hooks/post-sync
+++ b/contrib/caldav/hooks/post-sync
@@ -26,7 +26,7 @@ commit_dir() {
 	if [ -d .git ] && command -v git >/dev/null; then
 		git add "$@"
 		if ! git diff-index --quiet --cached HEAD; then
-			git commit -m "Automatic commit by the post-save hook"
+			git commit -m "Automatic commit by the post-sync hook"
 		fi
 	fi
 }


### PR DESCRIPTION
Calcurse is great! I appreciate your hard work.

I tried submitting this patch with git send-email (sent to bugs at calcurse dot org), but I think it may not have been received.

Gratefully,

Joseph