### PR TITLE
Add autopoint as a dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ install those as well:
 
 * gcc
 * automake
+* autopoint
 * asciidoc
 * gettext with development files
 * ncurses with development files


### PR DESCRIPTION
The gnu package `autopoint` is required to build this program, but it isn't listed in the README.