### PR TITLE
sha1: Fix checksum calculation on big-endian systems

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -47,7 +47,11 @@
 
 #define rol(val, n) (((val) << (n)) | ((val) >> (32 - (n))))
 
-#ifdef WORDS_BIGENDIAN
+/* We check for host system byte order using the __BYTE_ORDER__
+ * CPP macro which is available on many platforms but not mandated by
+ * the POSIX or C standard. As such, if __BYTE_ORDER__ is not set, we
+ * silently assume little endian byte order. */
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define blk0(i) block->l[i]
 #else
 #define blk0(i) (block->l[i] = (rol (block->l[i], 24) & \


### PR DESCRIPTION
Instead of using a custom macro which must be set manually to determine
host byte order (WORDS_BIGENDIAN) this commit uses the __BYTE_ORDER__
CPP macro which is commonly available on many systems [\[1\]][1]. If the macro
is not defined, little endian byte order is silently assumed which is
what the previous version of this code did anyhow. Alternatively, it
would also be possible to emit a #warning if __BYTE_ORDER__ is not set
or rewrite the code in a way that it does not depend on the native host
byte order in the first place [\[2\]][2].

This fixes the calcurse test suite on s390x.

Fixes #397

[1]: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
[2]: https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html

---

CC: @lhca