### PR TITLE
Display empty event description

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -307,7 +307,7 @@ struct conf {
 };
 
 #define EMPTY_DAY_DEFAULT "--"
-#define EMPTY_EVENT_DESC_DEFAULT "(empty description)"
+#define EMPTY_EVENT_DESC_DEFAULT _("(empty description)")
 
 /* Daemon-related configuration. */
 struct dmon_conf {

--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -307,6 +307,7 @@ struct conf {
 };
 
 #define EMPTY_DAY_DEFAULT "--"
+#define EMPTY_EVENT_DESC_DEFAULT "(empty description)"
 
 /* Daemon-related configuration. */
 struct dmon_conf {

--- a/src/day.c
+++ b/src/day.c
@@ -205,10 +205,9 @@ char *day_item_get_mesg(struct day_item *day)
 		return day->item.apt->mesg;
 	case EVNT:
 		message = day->item.ev->mesg;
-		if (*message != '\0')
-			return message;
-		else
+		if (*message == '\0')
 			return EMPTY_EVENT_DESC_DEFAULT;
+		return message;
 	case RECUR_APPT:
 		return day->item.rapt->mesg;
 	case RECUR_EVNT:

--- a/src/day.c
+++ b/src/day.c
@@ -198,11 +198,17 @@ static void day_add_item(int type, time_t start, time_t order, union aptev_ptr i
 /* Get the message of an item. */
 char *day_item_get_mesg(struct day_item *day)
 {
-	switch (day->type) {
+	char *message;
+	switch (day->type)
+	{
 	case APPT:
 		return day->item.apt->mesg;
 	case EVNT:
-		return day->item.ev->mesg;
+		message = day->item.ev->mesg;
+		if (*message != '\0')
+			return message;
+		else
+			return EMPTY_EVENT_DESC_DEFAULT;
 	case RECUR_APPT:
 		return day->item.rapt->mesg;
 	case RECUR_EVNT:


### PR DESCRIPTION
This PR addresses issue #422 When an event description is empty, it now shows '(empty description)'.

Fixes #422 

Signed-off-by: Jonathan van der Steege <jonathan@jonakeys.nl>