### PR TITLE
calcurse-caldav: Support PasswordCommand option

### DIFF
--- a/contrib/caldav/README.md
+++ b/contrib/caldav/README.md
@@ -34,13 +34,12 @@ argument. You can choose between the following initialization modes:
 For subsequent calcurse-caldav invocations, you don't need to specify any
 additional parameters.
 
-You can specify a username and password for basic authentication in the
-config file. Alternatively, the password can be passed securely from another
-program (such as *pass*) via the `CALCURSE_CALDAV_PASSWORD` environment variable like
-so:
-```
-CALCURSE_CALDAV_PASSWORD=$(pass show calcurse) calcurse-caldav
-```
+Specify your HTTP Basic authentication credentials under the config file's
+`Auth` section. The most secure approach is to save your password in a CLI
+encrypted password store (_e.g.,_ [pass](https://www.passwordstore.org/)), and
+then set `PasswordCommand` to the shell command used to retrieve it.
+If security is not a priority, you may store your password in plain text
+instead.
 
 Hooks
 -----

--- a/contrib/caldav/config.sample
+++ b/contrib/caldav/config.sample
@@ -48,11 +48,13 @@ DryRun = Yes
 # Enable this if you want detailed logs written to stdout.
 Verbose = Yes
 
-# Credentials for HTTP Basic Authentication. Leave this commented out if you do
-# not want to use authentication.
+# Credentials for HTTP Basic Authentication (if required).
+# Set `Password` to your password in plaintext (unsafe),
+# or `PasswordCommand` to a shell command that retrieves it (recommended).
 #[Auth]
 #Username = user
-#Password = pass
+#Password = password
+#PasswordCommand = pass baikal
 
 # Optionally specify additional HTTP headers here.
 #[CustomHeaders]


### PR DESCRIPTION
This commit adds a new `Auth/PasswordCommand` option
to support security best practices re: handling secrets
in CLI program configuration.

Prior to this commit, the two available options
for specifying a password were:

  1. via the `Auth/Password` config parameter, or
  2. via a `$CALCURSE_CALDAV_PASSWORD` environment variable.

The former is unsafe for obvious reasons;
the latter is unsafe because as long as the script is running,
its environment can be accessed via

    $ cat /proc/<pid>/environ

and is thus visible to anyone with access to the system.

This commit preserves preexisting behavior (for backward compatibility)
but removes all mention of option 2 from the README.
Since the README example for option 2 used a password command anyway,
there is little reason to continue its use,
and this commit recommends it be deprecated.