### PR TITLE
Assigning objects with static storage duration a zero value is redundant

### DIFF
--- a/src/day.c
+++ b/src/day.c
@@ -43,9 +43,9 @@
 #include "calcurse.h"
 
 static vector_t day_items;
-static unsigned day_items_nb = 0;
+static unsigned day_items_nb;
 
-struct day_item empty_day = { 0, 0, 0, {NULL}};
+struct day_item empty_day;
 
 /*
  * The day vector, day_items, is continuously rebuilt for display as the
@@ -54,7 +54,7 @@ struct day_item empty_day = { 0, 0, 0, {NULL}};
  * here that may later be used to refind the item in the rebuilt day
  * vector.
  */
-static struct day_item sel_data = { 0, 0, 0, {NULL}};
+static struct day_item sel_data;
 
 /*
  * Save the item to become the selected APP item.

--- a/src/ui-todo.c
+++ b/src/ui-todo.c
@@ -37,7 +37,7 @@
 #include "calcurse.h"
 #include <ctype.h>
 
-static unsigned ui_todo_view = 0;
+static unsigned ui_todo_view;
 
 static struct todo *ui_todo_selitem(void)
 {

--- a/src/vars.c
+++ b/src/vars.c
@@ -42,11 +42,11 @@
 /*
  * variables to store window size
  */
-int col = 0, row = 0;
-int resize = 0;
+int col, row;
+int resize;
 
 /* variable to tell if the terminal supports color */
-unsigned colorize = 0;
+unsigned colorize;
 
 /* Default background and foreground colors. */
 int foreground, background;
@@ -59,13 +59,13 @@ int foreground, background;
 enum ui_mode ui_mode = UI_CMDLINE;
 
 /* Don't save anything if this is set. */
-int read_only = 0;
+int read_only;
 
 /* Hide import/export message if set. */
-int quiet = 0;
+int quiet;
 
 /* Applications can trigger a reload by sending SIGUSR1. */
-int want_reload = 0;
+int want_reload;
 
 /* Strings describing each input date format. */
 const char *datefmt_str[DATE_FORMATS];
@@ -79,17 +79,17 @@ int days[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
  * variables to store data path names, which are initialized in
  * io_init()
  */
-char *path_ddir = NULL;
-char *path_cdir = NULL;
-char *path_todo = NULL;
-char *path_apts = NULL;
-char *path_conf = NULL;
-char *path_notes = NULL;
-char *path_keys = NULL;
-char *path_cpid = NULL;
-char *path_dpid = NULL;
-char *path_dmon_log = NULL;
-char *path_hooks = NULL;
+char *path_ddir;
+char *path_cdir;
+char *path_todo;
+char *path_apts;
+char *path_conf;
+char *path_notes;
+char *path_keys;
+char *path_cpid;
+char *path_dpid;
+char *path_dmon_log;
+char *path_hooks;
 
 /* Variable to store global configuration. */
 struct conf conf;


### PR DESCRIPTION
Assigning objects with static storage duration a zero value is redundant since this happens implicitly.
It's also inconsistent since we sometimes do it and sometimes don't.

Signed-off-by: Tom Schwindl <schwindl@posteo.de>