### PR TITLE
add notify-command format-specifiers %m, %d and %t - message, date and time resp.

### DIFF
--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -674,6 +674,7 @@ struct nbar {
 	char datefmt[BUFSIZ];	/* format for displaying date */
 	char timefmt[BUFSIZ];	/* format for displaying time */
 	char cmd[BUFSIZ];	/* notification command */
+        const char *shell;	/* user shell to launch notif. cmd */
 	unsigned notify_all;	/* notify all appointments */
 	pthread_mutex_t mutex;
 };


### PR DESCRIPTION
this is based on Ihca notify-review branch from December 2018