### PR TITLE
Fix segmentation fault when exporting ical file

### DIFF
--- a/src/ical.c
+++ b/src/ical.c
@@ -214,7 +214,8 @@ static void ical_export_note(FILE *stream, char *name)
 
 	asprintf(&note_file, "%s/%s", path_notes, name);
 	if (!(fp = fopen(note_file, "r")) || ungetc(getc(fp), fp) == EOF) {
-		fclose(fp);
+		if (fp)
+			fclose(fp);
 		return;
 	}
 	string_init(&note);


### PR DESCRIPTION
If a note file gets accidently deleted this leads to ical_export_note trying to execute fclose(NULL) which leads to a segmentation fault on current Debian GNU/Linux using libc6 (according to fclose's manpage, the behaviour is undefined in this case).

The fix tests whether fopen returned a non-NULL-pointer before trying to close it.