### PR TITLE
Correct the tense of data saving message

### DIFF
--- a/src/calcurse.c
+++ b/src/calcurse.c
@@ -267,16 +267,16 @@ static inline void key_generic_save(void)
 	wins_update(FLAG_ALL);
 	switch (ret) {
 	case IO_SAVE_CTINUE:
-		msg = _("Data were saved successfully");
+		msg = _("Data was saved successfully");
 		break;
 	case IO_SAVE_RELOAD:
-		msg = _("Data were saved/reloaded successfully");
+		msg = _("Data was saved/reloaded successfully");
 		break;
 	case IO_SAVE_CANCEL:
 		msg = _("Save cancelled");
 		break;
 	case IO_SAVE_NOOP:
-		msg = _("Data were already saved");
+		msg = _("Data was already saved");
 		break;
 	case IO_SAVE_ERROR:
 		EXIT(_("Cannot open data file"));
@@ -303,16 +303,16 @@ static inline void key_generic_reload(void)
 	switch (ret) {
 	case IO_RELOAD_LOAD:
 	case IO_RELOAD_CTINUE:
-		msg = _("Data were reloaded successfully");
+		msg = _("Data was reloaded successfully");
 		break;
 	case IO_RELOAD_MERGE:
-		msg = _("Date were merged/reloaded successfully");
+		msg = _("Date was merged/reloaded successfully");
 		break;
 	case IO_RELOAD_CANCEL:
 		msg = _("Reload cancelled");
 		break;
 	case IO_RELOAD_NOOP:
-		msg = _("Data were already loaded");
+		msg = _("Data was already loaded");
 		break;
 	case IO_RELOAD_ERROR:
 		EXIT(_("Cannot open data file"));


### PR DESCRIPTION
This resolves #489:
> The displayed text for when you save is not grammatically correct. It says:
> "Data were saved successfully"
> This is not correct as were is plural, the correct verb would be was, as it is singular. In this context data is singular so was should be used.

I probably didn't do this in the correct way, but editing the files in po/en.po which looked like localisation files didn't do anything when I tried, so feel free to correct this.
(this time on the correct the branch)