### PR TITLE
Fix notification command zombie processes

### DIFF
--- a/src/sigs.c
+++ b/src/sigs.c
@@ -85,6 +85,9 @@ static void generic_hdlr(int sig)
 		want_reload = 1;
 		ungetch(KEY_RESIZE);
 		break;
+	case SIGCHLD:
+		wait(NULL);
+		break;
 	}
 }
 
@@ -111,6 +114,7 @@ void sigs_init()
 	if (!sigs_set_hdlr(SIGWINCH, generic_hdlr)
 	    || !sigs_set_hdlr(SIGTERM, generic_hdlr)
 	    || !sigs_set_hdlr(SIGUSR1, generic_hdlr)
+	    || !sigs_set_hdlr(SIGCHLD, generic_hdlr)
 	    || !sigs_set_hdlr(SIGINT, SIG_IGN))
 		exit_calcurse(EXIT_FAILURE);
 }


### PR DESCRIPTION
This PR fixes #390 by waiting for state changes in child processes from the notification command, which prevents zombie processes from accumulating.