### PR TITLE
calcurse-caldav: use flock to prevent concurrent instances

### DIFF
--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -3,6 +3,7 @@
 import argparse
 import base64
 import configparser
+import fcntl
 import os
 import pathlib
 import re
@@ -732,12 +733,12 @@ elif ver < (4, 0, 0, 96):
 # Run the pre-sync hook.
 run_hook('pre-sync')
 
-# Create lock file.
-if os.path.exists(lockfn):
-    die('Leftover lock file detected. If there is no other synchronization ' +
-        'instance running, please remove the lock file manually and try ' +
-        'again.')
-open(lockfn, 'w')
+# Obtain lock.
+try:
+    lockfile = open(lockfn, 'w')
+    fcntl.flock(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except OSError:
+    die('Another synchronization instance is already running.')
 
 try:
     # Connect to the server.
@@ -811,8 +812,7 @@ try:
         conn.clear_credentials()
 
 finally:
-    # Remove lock file.
-    os.remove(lockfn)
+    pass
 
 # Run the post-sync hook.
 run_hook('post-sync')


### PR DESCRIPTION
The current locking implementation has two issues:
1. There is a race condition between checking for lockfile existance and creating it
2. A process holding the lock can die without removing the file

This commit fixes both problems with a new locking implementation. To obtain the lock, a process obtains an exclusive flock on the lockfile, creating the file if it doesn't exist. The kernel takes care of removing the flock once the locked descriptor is closed (i.e. when the process exits).