### PR TITLE
Change iCal default extension from "ical" to "ics"

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -79,7 +79,7 @@ static FILE *get_export_stream(enum export_type type)
 	const char *wrong_name =
 	    _("The file cannot be accessed, please enter another file name.");
 	const char *press_enter = _("Press [ENTER] to continue.");
-	const char *file_ext[IO_EXPORT_NBTYPES] = { "ical", "txt" };
+	const char *file_ext[IO_EXPORT_NBTYPES] = { "ics", "txt" };
 
 	stream = NULL;
 	if ((home = getenv("HOME")) != NULL)


### PR DESCRIPTION
RFC 5545 Section 8.1 [1] specifies that the extension for iCalendar
files is "ics":

> File extension(s):  The file extension of "ics" is to be used to
> designate a file containing (an arbitrary set of) calendaring and
> scheduling information consistent with this MIME content type.

[1] https://www.ietf.org/rfc/rfc5545.txt
