### PR TITLE
Ignore empty CalDAV entry to allow syncing to continue

### DIFF
--- a/contrib/caldav/calcurse-caldav.py
+++ b/contrib/caldav/calcurse-caldav.py
@@ -537,6 +537,11 @@ def pull_objects(hrefs_missing, hrefs_modified, conn, syncdb, etagdict):
             die_atnode('Missing calendar data.', node)
         cdata = cdatanode.text
 
+        if cdata is None:
+            if verbose:
+                print("Ignoring empty object {}.".format(etag))
+            continue
+
         if href in hrefs_modified:
             if verbose:
                 print("Replacing object {}.".format(etag))


### PR DESCRIPTION
I don't entirely know why the CalDAV server I was using came back with a response like this, but failing to encode the None as UTF-8 didn't feel like desirable behaviour.

If we just ignore it and continue then the sync works great, so that seemed like the simplest thing to do.

Don't know if this is affecting anyone else, but presumably it could and hopefully the change isn't too scary.