### PR TITLE
Initialize locale independently of NLS

### DIFF
--- a/src/calcurse.c
+++ b/src/calcurse.c
@@ -34,6 +34,7 @@
  *
  */
 
+#include <locale.h>
 #include <stdlib.h>
 
 #include "calcurse.h"
@@ -696,8 +697,8 @@ cleanup:
  */
 int main(int argc, char **argv)
 {
-#if ENABLE_NLS
 	setlocale(LC_ALL, "");
+#if ENABLE_NLS
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
 #endif /* ENABLE_NLS */

--- a/src/calcurse.h
+++ b/src/calcurse.h
@@ -62,7 +62,6 @@
 
 /* Internationalization. */
 #if ENABLE_NLS
-#include <locale.h>
 #include <libintl.h>
 #undef _
 #define _(String) gettext(String)

--- a/src/utils.c
+++ b/src/utils.c
@@ -47,6 +47,7 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <termios.h>
+#include <locale.h>
 
 #include "calcurse.h"
 #include "sha1.h"
@@ -495,20 +496,16 @@ int date_cmp_day(time_t d1, time_t d2)
 /* Generic function to format date. */
 void date_sec2date_fmt(time_t sec, const char *fmt, char *datef)
 {
-#if ENABLE_NLS
 	/* TODO: Find a better way to deal with localization and strftime(). */
 	char *locale_old = mem_strdup(setlocale(LC_ALL, NULL));
 	setlocale(LC_ALL, "C");
-#endif
 
 	struct tm lt;
 	localtime_r(&sec, &lt);
 	strftime(datef, BUFSIZ, fmt, &lt);
 
-#if ENABLE_NLS
 	setlocale(LC_ALL, locale_old);
 	mem_free(locale_old);
-#endif
 }
 
 /* Return a string containing the date, given a date in seconds. */


### PR DESCRIPTION
`--disable-nls` should only disable `gettext` translations, and should still call `setlocale(LC_ALL, ...)`. Otherwise, user-entered CJK texts (eg. appointment names) may get displayed as garbled texts.